### PR TITLE
ensure ts server file is rebuilt and prevent process handlers being readded on server restart

### DIFF
--- a/plugins/exceptions.js
+++ b/plugins/exceptions.js
@@ -425,15 +425,21 @@ class ProcessExceptionHandlers {
   }
 }
 
+let handlersAdded = false;
+
 export default fp(async function exceptions(fastify, { grace }) {
-  const procExp = new ProcessExceptionHandlers(fastify.log);
-  procExp.closeOnExit(fastify, { grace: grace });
+  if (!handlersAdded) {
+    const procExp = new ProcessExceptionHandlers(fastify.log);
+    procExp.closeOnExit(fastify, { grace: grace });
 
-  // @ts-ignore
-  if (!fastify.metricStreams) {
-    fastify.decorate("metricStreams", []);
+    handlersAdded = true;
+
+    // @ts-ignore
+    if (!fastify.metricStreams) {
+      fastify.decorate("metricStreams", []);
+    }
+
+    // @ts-ignore
+    fastify.metricStreams.push(procExp.metrics);
   }
-
-  // @ts-ignore
-  fastify.metricStreams.push(procExp.metrics);
 });


### PR DESCRIPTION
2 issues are addressed with this PR:

1. Process exception handlers were being added again every time the server was restart in dev mode
2. TS version of the server file was not refreshing when the server was restarted because its built file was only done 1x on initial server load

This PR fixes these 2 issues.