### PR TITLE
print coloured information messages and clear console on restarts and rebundles

### DIFF
--- a/api/dev.js
+++ b/api/dev.js
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import chokidar from "chokidar";
 import { context } from "esbuild";
@@ -5,8 +6,13 @@ import pino from "pino";
 import sandbox from "fastify-sandbox";
 import { start } from "@fastify/restartable";
 import httpError from "http-errors";
+import ora from "ora";
 import fastifyPodletPlugin from "../lib/plugin.js";
 import PathResolver from "../lib/path.js";
+import chalk from "chalk";
+import boxen from "boxen";
+
+const { version } = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), { encoding: "utf8" }));
 
 const joinURLPathSegments = (...segments) => {
   return segments.join("/").replace(/[\/]+/g, "/");
@@ -14,6 +20,11 @@ const joinURLPathSegments = (...segments) => {
 
 export async function dev({ config, cwd = process.cwd() }) {
   config.set("assets.development", true);
+
+  console.log(chalk.magenta("\nStarting Podium podlet server [development mode]...\n"))
+  const spinner = ora({
+    spinner: "point",
+  });
 
   const LOGGER = pino({
     transport: {
@@ -49,6 +60,7 @@ export async function dev({ config, cwd = process.cwd() }) {
     entryPoints.push(LAZY_FILEPATH.path);
   }
 
+  spinner.succeed(chalk.cyan("build plugins loaded"));
   // support user defined plugins via a build.js file
   const plugins = [];
   if (BUILD_FILEPATH.exists) {
@@ -78,16 +90,28 @@ export async function dev({ config, cwd = process.cwd() }) {
     plugins,
   });
 
+  spinner.succeed(chalk.cyan("bundles built"));
+
   // Chokidar provides super fast native file system watching
-  const clientWatcher = chokidar.watch(["content.*", "fallback.*", "scripts.*", "lazy.*", "client/**/*"], {
-    persistent: true,
-    followSymlinks: false,
-    cwd,
-  });
+  const clientWatcher = chokidar.watch(
+    ["content.*", "fallback.*", "scripts.*", "lazy.*", "client/**/*", "lib/**/*", "src/**/*"],
+    {
+      persistent: true,
+      followSymlinks: false,
+      cwd,
+    }
+  );
 
   // rebuild the client side bundle whenever a client side related file changes
-  clientWatcher.on("change", async () => {
+  clientWatcher.on("change", async (filename) => {
+    console.clear();
+    const greeting = chalk.white.bold(`Podium Podlet Server (v${version})`);
+    const msgBox = boxen(greeting, { padding: 0.5 });
+    console.log(msgBox);
+    spinner.succeed(chalk.cyan(`change detected in ${filename}`));
     await buildContext.rebuild();
+    spinner.succeed(chalk.cyan("bundles rebuilt"));
+    console.log(chalk.green("\ndisplaying log output:\n"));
   });
 
   // Esbuild built in server which provides an SSE endpoint the client can subscribe to
@@ -95,6 +119,7 @@ export async function dev({ config, cwd = process.cwd() }) {
   // new EventSource('http://localhost:6935/esbuild').addEventListener('change', () => { location.reload() });
   await buildContext.serve({ port: 6935 });
 
+  spinner.succeed(chalk.cyan("live reload server started"));
   // Create and start a development server
   const started = await start({
     logger: LOGGER,
@@ -159,6 +184,8 @@ export async function dev({ config, cwd = process.cwd() }) {
     ignoreTrailingSlash: true,
   });
 
+  spinner.succeed(chalk.cyan("server started"));
+
   // Chokidar provides super fast native file system watching
   // of server files. Either server.js/ts or any js/ts files inside a folder named server
   const serverWatcher = chokidar.watch(["server.*", "server/**/*"], {
@@ -170,14 +197,26 @@ export async function dev({ config, cwd = process.cwd() }) {
     buildContext.dispose();
   });
 
+  console.log(chalk.green("\ndisplaying log output:\n"));
+
   // restart the server whenever a server related file changes
-  serverWatcher.on("change", async () => {
+  serverWatcher.on("change", async (filename) => {
+    console.clear();
+    const greeting = chalk.white.bold(`Podium Podlet Server (v${version})`);
+    const msgBox = boxen(greeting, { padding: 0.5 });
+    console.log(msgBox);
+    spinner.succeed(chalk.cyan(`change detected in ${filename}`));
+    // TODO::
+    // check a hash of the server.js/ts file and ensure changedFilename has actually changed
+    // this might be slower than just always restarting though... measure.
     try {
       await started.restart();
     } catch (err) {
       console.log(err);
       buildContext.dispose();
     }
+    spinner.succeed(chalk.cyan("server restarted"));
+    console.log(chalk.green("\ndisplaying log output:\n"));
   });
 
   // start the server for the first time

--- a/cli.js
+++ b/cli.js
@@ -12,6 +12,7 @@ const { version } = JSON.parse(readFileSync(new URL("./package.json", import.met
 const greeting = chalk.white.bold(`Podium Podlet Server (v${version})`);
 
 const msgBox = boxen(greeting, { padding: 0.5 });
+console.clear();
 console.log(msgBox);
 
 yargs(process.argv.slice(2))

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lit": "^2.6.1",
     "lodash.merge": "^4.6.2",
     "minify-html-literals": "^1.3.5",
+    "ora": "^6.1.2",
     "pino": "^8.10.0",
     "pino-pretty": "^10.0.0",
     "prom-client": "^14.1.1",


### PR DESCRIPTION
This PR cleans up the terminal output of the cli in dev mode.

* coloured messages
* clear terminal noise between runs and when rebuilding bundles and restarting the server

For example:
![Screen Shot 2023-03-15 at 14 50 59](https://user-images.githubusercontent.com/1177098/225183970-44ff7d87-6398-4b3c-a5b5-9214fef8af23.png)
