### PR TITLE
Add e2e tests

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -38,8 +38,12 @@ export default async function configuration({ cwd = process.cwd() }) {
   }
 
   // name defaults to the name field in package.json
-  const { name } = JSON.parse(await readFile(join(cwd, "package.json"), { encoding: "utf8" }));
-  config.load({ app: { name } });
+  let name;
+  const packagePath = join(cwd, "package.json");
+  if (existsSync(packagePath)) {
+    name = JSON.parse(await readFile(packagePath, { encoding: "utf8" })).name;
+    config.load({ app: { name } });
+  }
 
   // if a fallback is defined, set the fallback path
   // this is so that the Podlet object fallback setting does not get set if no fallback is defined.
@@ -71,7 +75,9 @@ export default async function configuration({ cwd = process.cwd() }) {
 
   // validate the name field of package.json
   if (name === config.get("app.name") && !/^[a-z-]*$/.test(name)) {
-    throw new Error(`Name field in package.json was not usable as a default app name because it uses characters other than a-z and -.\nYou have 2 choices:\n1. Either set it to a different name using lower case letters and the - character\n2. keep it as is and define the app name in config.\nA good place for this is in /config/common.json\neg. { "app": { "name": "my-app-name-here" } }"`)
+    throw new Error(
+      `Name field in package.json was not usable as a default app name because it uses characters other than a-z and -.\nYou have 2 choices:\n1. Either set it to a different name using lower case letters and the - character\n2. keep it as is and define the app name in config.\nA good place for this is in /config/common.json\neg. { "app": { "name": "my-app-name-here" } }"`
+    );
   }
 
   // If app.base is not explicitly user set, then default it to the same as app.name with a leading slash

--- a/test/api/start.test.js
+++ b/test/api/start.test.js
@@ -73,3 +73,169 @@ test("Starting with content file in directory", async (t) => {
 
   await app.close();
 });
+
+// Test for using validated query parameters in server.js
+test("Using validated query parameters in server.js", async (t) => {
+  await mkdir(join(tmp, "schemas"));
+  const contentSchema = {
+    querystring: {
+      type: "object",
+      properties: {
+        id: { type: "integer" },
+      },
+      required: ["id"],
+    },
+  };
+
+  await writeFile(join(tmp, "schemas", "content.json"), JSON.stringify(contentSchema));
+  await writeFile(
+    join(tmp, "server.js"),
+    `
+    export default async function server(app) {
+      app.setContentState(async ({ query }) => {
+        const { id } = query;
+        return { id };
+      });
+    }
+  `.trim()
+  );
+  await writeFile(
+    join(tmp, "package.json"),
+    JSON.stringify({ name: "test-app", type: "module", dependencies: { lit: "*" } })
+  );
+  await writeFile(
+    join(tmp, "content.js"),
+    `
+    import { html, LitElement } from "lit";
+    export default class Content extends LitElement {
+        render() { 
+            return html\`<div>hello world</div>\`;
+        }
+    }
+    `.trim()
+  );
+  execSync("npm install", { cwd: tmp });
+  const config = await configuration({ cwd: tmp });
+  config.set("app.port", 0);
+  config.set("app.logLevel", "FATAL");
+
+  await build({ config, cwd: tmp });
+  const app = await start({ config, cwd: tmp });
+
+  const validRes = await fetch(`${app.address}/test-app?id=1`);
+  t.equal(validRes.status, 200, "App should respond on content route with valid query parameter");
+
+  const invalidRes = await fetch(`${app.address}/test-app?id=invalid`);
+  t.equal(invalidRes.status, 400, "App should respond with a 400 status for invalid query parameter");
+
+  await app.close();
+});
+
+test("Fallback route", async (t) => {
+  await writeFile(
+    join(tmp, "fallback.js"),
+    `
+  import { html, LitElement } from "lit";
+  export default class Content extends LitElement {
+      render() { 
+          return html\`<div>Fallback content</div>\`;
+      }
+  }
+  `.trim()
+  );
+  await writeFile(
+    join(tmp, "package.json"),
+    JSON.stringify({ name: "test-app", type: "module", dependencies: { lit: "*" } })
+  );
+  execSync("npm install", { cwd: tmp });
+  const config = await configuration({ cwd: tmp });
+  config.set("app.port", 0);
+  config.set("app.logLevel", "FATAL");
+  await build({ config, cwd: tmp });
+  const app = await start({ config, cwd: tmp });
+
+  const res = await fetch(`${app.address}/test-app/fallback`);
+  const markup = await res.text();
+  t.equal(res.status, 200, "App should respond on fallback route");
+  t.match(markup, "<div>Fallback content</div>", "Fallback content should be displayed");
+
+  await app.close();
+});
+
+// Test for scripts.js loading
+test("scripts.js loading", async (t) => {
+  await writeFile(
+    join(tmp, "scripts.js"),
+    `
+    console.log("This script will be loaded after the main podlet scripts.");
+  `.trim()
+  );
+  await writeFile(
+    join(tmp, "package.json"),
+    JSON.stringify({ name: "test-app", type: "module", dependencies: { lit: "*" } })
+  );
+  await writeFile(
+    join(tmp, "content.js"),
+    `
+    import { html, LitElement } from "lit";
+    export default class Content extends LitElement {
+        render() { 
+            return html\`<div>hello world</div>\`;
+        }
+    }
+    `.trim()
+  );
+  execSync("npm install", { cwd: tmp });
+  const config = await configuration({ cwd: tmp });
+  config.set("app.port", 0);
+  config.set("app.logLevel", "FATAL");
+  config.set("app.mode", "ssrOnly");
+  await build({ config, cwd: tmp });
+  const app = await start({ config, cwd: tmp });
+
+  const res = await fetch(`${app.address}/test-app/static/client/scripts.js`);
+  const content = await res.text();
+  t.equal(res.status, 200, "App should respond on scripts.js route");
+  t.match(content, "This script will be loaded after the main podlet scripts.", "scripts.js content should be correct");
+
+  await app.close();
+});
+
+// Test for lazy.js loading
+test("lazy.js loading", async (t) => {
+  await writeFile(
+    join(tmp, "lazy.js"),
+    `
+    console.log("This script is lazy-loaded after the window load event.");
+  `.trim()
+  );
+
+  await writeFile(
+    join(tmp, "content.js"),
+    `
+    import { html, LitElement } from "lit";
+    export default class Content extends LitElement {
+        render() { 
+            return html\`<div>hello world</div>\`;
+        }
+    }
+    `.trim()
+  );
+  await writeFile(
+    join(tmp, "package.json"),
+    JSON.stringify({ name: "test-app", type: "module", dependencies: { lit: "*" } })
+  );
+  execSync("npm install", { cwd: tmp });
+  const config = await configuration({ cwd: tmp });
+  config.set("app.port", 0);
+  config.set("app.logLevel", "FATAL");
+  await build({ config, cwd: tmp });
+  const app = await start({ config, cwd: tmp });
+
+  const res = await fetch(`${app.address}/test-app/static/client/lazy.js`);
+  const content = await res.text();
+  t.equal(res.status, 200, "App should respond on lazy.js route");
+  t.match(content, "This script is lazy-loaded after the window load event.", "lazy.js content should be correct");
+
+  await app.close();
+});

--- a/test/api/start.test.js
+++ b/test/api/start.test.js
@@ -1,0 +1,75 @@
+import { execSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { test, beforeEach, afterEach } from "tap";
+import configuration from "../../lib/config.js";
+import { build } from "../../api/build.js";
+import { start } from "../../api/start.js";
+
+const tmp = join(tmpdir(), "./api.test.js");
+
+beforeEach(async (t) => {
+  await mkdir(tmp);
+});
+
+afterEach(async (t) => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+test("Starting with no files in directory", async (t) => {
+  const config = await configuration({ cwd: tmp });
+  config.set("app.port", 0);
+  config.set("app.logLevel", "FATAL");
+  // @ts-ignore
+  config.set("app.base", "/test-app");
+  // @ts-ignore
+  config.set("app.name", "test-app");
+  await build({ config, cwd: tmp });
+  const app = await start({ config, cwd: tmp });
+  const res = await fetch(`${app.address}/test-app/manifest.json`);
+  t.equal(res.status, 200, "App should respond on manifest route");
+  await app.close();
+});
+
+test("Starting with package.json file in directory", async (t) => {
+  await writeFile(join(tmp, "package.json"), JSON.stringify({ name: "test-app" }));
+  const config = await configuration({ cwd: tmp });
+  config.set("app.port", 0);
+  config.set("app.logLevel", "FATAL");
+  await build({ config, cwd: tmp });
+  const app = await start({ config, cwd: tmp });
+  const res = await fetch(`${app.address}/test-app/manifest.json`);
+  t.equal(res.status, 200, "App should respond on manifest route");
+  await app.close();
+});
+
+test("Starting with content file in directory", async (t) => {
+  await writeFile(
+    join(tmp, "package.json"),
+    JSON.stringify({ name: "test-app", type: "module", dependencies: { lit: "*" } })
+  );
+  await writeFile(
+    join(tmp, "content.js"),
+    `
+    import { html, LitElement } from "lit";
+    export default class Content extends LitElement {
+        render() { 
+            return html\`<div>hello world</div>\`;
+        }
+    }
+    `.trim()
+  );
+  execSync("npm install", { cwd: tmp });
+  const config = await configuration({ cwd: tmp });
+  config.set("app.port", 0);
+  config.set("app.logLevel", "FATAL");
+  await build({ config, cwd: tmp });
+  const app = await start({ config, cwd: tmp });
+  const res = await fetch(`${app.address}/test-app`);
+  const markup = await res.text();
+  t.equal(res.status, 200, "App should respond on content route");
+  t.match(markup, "<div>hello world</div>", "Content should be hello world");
+
+  await app.close();
+});


### PR DESCRIPTION
Adds a set of happy path e2e tests.

Tests cover
* starting and building the app
* validation
* manifest
* scripts
* content
* fallback
* lazy script loading

During the process of writing these tests, the following changes needed to be made:
* api/start.js now returns an object with an `address` property and a `close` function so that the server can be shutdown.
* setting the log level now works
* passing in cwd to /lib/plugin.js now works properly
* In its most basic case, the app can be run without a package.json file (though as soon as you add a content.js file, you need to have lit installed)