### PR TITLE
fix: Fix premature close

### DIFF
--- a/api/dev.js
+++ b/api/dev.js
@@ -231,7 +231,7 @@ export async function dev({ config, cwd = process.cwd() }) {
 
   // Chokidar provides super fast native file system watching
   // of server files. Either server.js/ts or any js/ts files inside a folder named server
-  const serverWatcher = chokidar.watch(["server.*", "server/**/*"], {
+  const serverWatcher = chokidar.watch(["server.[js][ts]g", "server/**/*"], {
     persistent: true,
     followSymlinks: false,
     cwd,


### PR DESCRIPTION
This fixes an issue where the loading of a podlet would just hang and not properly load on some (random) machines in dev mode when a server.js file was present in the project. For those this would happen, the server would also output `Premature close` errors in the log.

```sh
[09:22:47 UTC] ERROR: premature close
    reqId: "req-7"
    err: {
      "type": "Error",
      "message": "premature close",
      "stack":
          Error: premature close
              at onclosenexttick (/home/trygve/dev/podium/podlet-server/node_modules/end-of-stream/index.js:54:86)
              at process.processTicksAndRejections (node:internal/process/task_queues:77:11)
    }
```

What causes this is that in dev mode the whole plugin is loaded twice into fastify when the file system listener for live reloads is attached. This would result in a server which holds a duplicate set of all routes registered which then would cause a request to a route to executed the code for a route twice in parallel. In this race one would win, close the underlying stream causing the second execution to try to write to a stream which was closed and then fail on that resulting in the compression module to choke and just make things hang.

The issue seems to be the glob for how the listener for live reload scans for the server file when we try to support both different types of extensions on the server file in it self. Being explicit on listening for a `.js` and `.ts` extension seems to fix this.

That this is tied to the listening for file changes is probably explaining why this error happened for some and not others due to the fact that events for listen for changes in files might vary depending on OS, how fast the computer, disc is etc.