### PR TITLE
feat: set grace to 0 in dev, default to 5000 and allow override

### DIFF
--- a/lib/config-schema.js
+++ b/lib/config-schema.js
@@ -65,7 +65,7 @@ export const schema = {
     grace: {
       doc: "Shutdown grace period",
       format: Number,
-      default: 0,
+      default: 5000,
     },
     compression: {
       doc: "Enables/disables compression on routes",

--- a/lib/config.js
+++ b/lib/config.js
@@ -34,7 +34,7 @@ export default async function configuration({ cwd = process.cwd() }) {
   // programmatically set defaults for cases
   // locally, default to development mode
   if (env === "local") {
-    config.load({ app: { development: true } });
+    config.load({ app: { development: true, grace: 0 } });
   }
 
   // name defaults to the name field in package.json

--- a/test/lib/config.test.js
+++ b/test/lib/config.test.js
@@ -222,3 +222,30 @@ test("When domain/env specific config is defined, values within override config/
   process.env.ENV = env;
   process.env.HOST = host;
 });
+
+test("app.grace when running in development", async (t) => {
+  const env = process.env.ENV;
+  process.env.ENV = "local";
+  await mkdir(join(tmp, "config"));
+  const config = await configuration({ cwd: tmp });
+  t.equal(config.get("app.grace"), 0, "app.grace should equal 0");
+  // reset env
+  process.env.ENV = env;
+});
+
+test("app.grace when not running in development", async (t) => {
+  const env = process.env.ENV;
+  process.env.ENV = "prod";
+  await mkdir(join(tmp, "config"));
+  const config = await configuration({ cwd: tmp });
+  t.equal(config.get("app.grace"), 5000, "app.grace should equal 5000");
+  // reset env
+  process.env.ENV = env;
+});
+
+test("app.grace when overridden", async (t) => {
+  await mkdir(join(tmp, "config"));
+  await writeFile(join(tmp, "config", "common.json"), JSON.stringify({ app: { grace: 2500 } }));
+  const config = await configuration({ cwd: tmp });
+  t.equal(config.get("app.grace"), 2500, "app.grace should equal 2500");
+});


### PR DESCRIPTION
While still allowing the user to override this value as they see fit, app shutdown grace is defaulted to 5000 and set to 0 for development.

Fixes https://github.com/podium-lib/podlet-server/issues/14