### PR TITLE
fix: Use http-errors on internal errors

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -118,9 +118,9 @@ export default fp(async function (
       await f.register(scriptsPn, { enabled: scripts, base: assetBase });
       await f.register(liveReloadPn, { development });
       await f.register(compressionPn, { enabled: compression });
+      await f.register(errorsPn);
       await f.register(assetsPn, { base, cwd });
       await f.register(dependenciesPn, { enabled: development, cwd });
-      await f.register(errorsPn);
       await f.register(exceptionsPn, { grace: grace });
       await f.register(hydratePn, { appName: name, base: assetBase, development });
       await f.register(csrPn, { appName: name, base: assetBase, development });

--- a/plugins/dependencies.js
+++ b/plugins/dependencies.js
@@ -31,6 +31,7 @@ export default fp(async function dependencies(fastify, { enabled = false, cwd = 
           // resolve the full path to the dependency using node's dep resolving mechanism
           filepath = require.resolve(depname, { paths: [cwd] });
         } catch (err) {
+          fastify.log.debug(`Unable to resolve file path for ${depname}. Is this dependency installed?`);
           throw new httpError.NotFound();
         }
 
@@ -48,6 +49,7 @@ export default fp(async function dependencies(fastify, { enabled = false, cwd = 
             sourcemap: "inline",
           });
         } catch (err) {
+          fastify.log.debug(`Unable to bundle file ${filepath}`);
           throw new httpError.InternalServerError();
         }
 
@@ -56,6 +58,7 @@ export default fp(async function dependencies(fastify, { enabled = false, cwd = 
           // read the file contents back into mem
           contents = await readFile(outfile, { encoding: "utf8" });
         } catch (err) {
+          fastify.log.debug(`Unable to read file ${outfile}`);
           throw new httpError.InternalServerError();
         }
 

--- a/plugins/dependencies.js
+++ b/plugins/dependencies.js
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { readFile } from "node:fs/promises";
 import esbuild from "esbuild";
 import fp from "fastify-plugin";
+import httpError from 'http-errors';
 
 const require = createRequire(import.meta.url);
 const tmp = join(tmpdir(), crypto.randomUUID());
@@ -30,12 +31,7 @@ export default fp(async function dependencies(fastify, { enabled = false, cwd = 
           // resolve the full path to the dependency using node's dep resolving mechanism
           filepath = require.resolve(depname, { paths: [cwd] });
         } catch (err) {
-          return reply
-            .status(404)
-            .send({
-              statusCode: 404,
-              message: `Unable to resolve file path for ${depname}. Is this dependency installed?`,
-            });
+          throw new httpError.NotFound();
         }
 
         let outfile = "";
@@ -52,7 +48,7 @@ export default fp(async function dependencies(fastify, { enabled = false, cwd = 
             sourcemap: "inline",
           });
         } catch (err) {
-          return reply.status(500).send({ statusCode: 500, message: `Unable to bundle file ${filepath}` });
+          throw new httpError.InternalServerError();
         }
 
         let contents = "";
@@ -60,7 +56,7 @@ export default fp(async function dependencies(fastify, { enabled = false, cwd = 
           // read the file contents back into mem
           contents = await readFile(outfile, { encoding: "utf8" });
         } catch (err) {
-          return reply.status(500).send({ statusCode: 500, message: `Unable to read file ${outfile}` });
+          throw new httpError.InternalServerError();
         }
 
         // cache file contents

--- a/test/plugins/plugins-dependencies.test.js
+++ b/test/plugins/plugins-dependencies.test.js
@@ -73,7 +73,8 @@ test("non-existent dependency results in a 404 error", async (t) => {
     response,
     {
       statusCode: 404,
-      message: "Unable to resolve file path for does-not-exist. Is this dependency installed?",
+      message: "Not Found",
+      error: "Not Found",
     },
     "should respond with error object"
   );


### PR DESCRIPTION
Use `http-errors` when dealing with serving http errors. This align with what developers of podlets should do while it also avoids dealing with returning / sending errors in routes (its delegated to the error handler instead).