### PR TITLE
feat: add document.js to support Podium document template

### DIFF
--- a/GUIDE_DOCUMENT.md
+++ b/GUIDE_DOCUMENT.md
@@ -1,0 +1,68 @@
+Advanced Guide: Using Podium Document templates
+===============================================
+
+This advanced guide assumes that you have already completed the beginner's guide and are familiar with the basics of setting up and running a Podium podlet server. In this guide, we will cover how to use the Podium Document feature to define a custom document template in your Podium podlet application using a `document.js` or `document.ts` file.
+
+Step 1: Create the document.js or document.ts file
+--------------------------------------------------
+
+In the root of your project, create a new file named `document.js` or `document.ts`. This is where you will define your custom document template for your Podium podlet application.
+
+For example:
+
+sh
+
+```sh
+touch document.js
+```
+
+Step 2: Define the custom document template
+-------------------------------------------
+
+Open the `document.js` or `document.ts` file and define a custom document template by exporting a function that returns a string representing the HTML document.
+
+Here's an example of a custom document template in `document.js`:
+
+javascript
+
+```javascript
+// document.js
+export default (incoming, fragment, head) => `
+<!doctype html>
+<html lang="${incoming.context.locale}">
+    <head>
+        <meta charset="${incoming.view.encoding}">
+        <title>${incoming.view.title}</title>
+        ${head}
+    </head>
+    <body>
+        ${fragment}
+    </body>
+</html>`;
+```
+
+In a TypeScript `document.ts` file, make sure to import and use the proper types:
+
+typescript
+
+```typescript
+// document.ts
+import { HttpIncoming } from "@podium/podlet";
+
+export default (incoming: HttpIncoming<{ [key: string]: unknown }>, fragment: string, head: string): string => `
+<!doctype html>
+<html lang="${incoming.context.locale}">
+    <head>
+        <meta charset="${incoming.view.encoding}">
+        <title>${incoming.view.title}</title>
+        ${head}
+    </head>
+    <body>
+        ${fragment}
+    </body>
+</html>`;
+```
+
+That's it! You have now successfully used the Podium Document feature to define a custom document template in your Podium podlet application. This custom document template will be used when serving the podlet content, ensuring consistent styling and structure across both development and production environments.
+
+To learn more about Podium Document and how it can be used in podlet applications, refer to the official Podium documentation site: [https://podium-lib.io/docs/api/document](https://podium-lib.io/docs/api/document)%

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Alternatively, an app might features such as config, localisation, additional se
   build.js
   scripts.js
   lazy.js
+  document.js
   package.json
   /config
     schema.js
@@ -127,6 +128,28 @@ additional scripting to the SSR'd content.
 
 This file can be used to lazy load additional client side scripts after the window load event has fired. This is useful for adding tracking scripts or other
 scripts that aren't needed on initial page load. Using this can help to get your initial bundle weight down and get pixels on the screen faster.
+
+#### **document.js [optional]**
+
+This file can be used to add a Podium document template
+
+```javascript
+// document.js
+export default (incoming, fragment, head) => `
+<!doctype html>
+<html lang="${incoming.context.locale}">
+    <head>
+        <meta charset="${incoming.view.encoding}">
+        <title>${incoming.view.title}</title>
+        ${head}
+    </head>
+    <body>
+        ${fragment}
+    </body>
+</html>`;
+```
+
+See [the Podium docs](https://podium-lib.io/docs/api/document) for more information.
 
 #### **server.js [optional]**
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -22,6 +22,7 @@ import lazyPn from "../plugins/lazy.js";
 import scriptsPn from "../plugins/scripts.js";
 import ssrPn from "../plugins/ssr.js";
 import csrPn from "../plugins/csr.js";
+import documentPn from "../plugins/document.js";
 
 const isAbsoluteURL = (pathOrUrl) => {
   const url = new URL(pathOrUrl, "http://local");
@@ -134,6 +135,7 @@ export default fp(async function (
         groupStatusCodes,
       });
       await f.register(validationPn, { prefix, defaults, mappings: { "/": "content.json" }, cwd });
+      await f.register(documentPn, { podlet, cwd, development, });
 
       // routes
 

--- a/plugins/document.js
+++ b/plugins/document.js
@@ -1,0 +1,26 @@
+import fp from "fastify-plugin";
+import PathResolver from "../lib/path.js";
+
+/**
+ * @typedef {{ podlet: import("@podium/podlet").default, cwd: string, development: boolean }} DocumentPluginOptions
+ */
+
+export default fp(async function documentPlugin(
+  fastify,
+  /**@type {DocumentPluginOptions}*/
+  { podlet, cwd, development }
+) {
+  // check if document.js or document.ts are present in cwd
+  // if so, first transpile document.ts file (if present) to .js file and then load/read document.js and register it as a podlet view
+  // if not, do nothing
+  const resolver = new PathResolver({ cwd, development });
+  const documentFile = await resolver.resolve("./document");
+  if (documentFile.exists) {
+    try {
+      const document = await resolver.import("./document");
+      podlet.view(document.default);
+    } catch (err) {
+      fastify.log.debug(`document.js file located but could not be loaded. Error: ${err.message}`);
+    }
+  }
+});

--- a/test/plugins/plugins-document.test.js
+++ b/test/plugins/plugins-document.test.js
@@ -1,0 +1,36 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { test, beforeEach } from "tap";
+import fastify from "fastify";
+import Podlet from "@podium/podlet";
+import plugin from "../../plugins/document.js";
+
+const tmp = join(tmpdir(), "./plugins-document.test.js");
+
+beforeEach(async (t) => {
+  await rm(tmp, { recursive: true, force: true });
+  await mkdir(tmp);
+  await writeFile(join(tmp, "package.json"), JSON.stringify({ name: "test", type: "module" }));
+  t.context.app = fastify({ logger: false });
+});
+
+test("Basic document template is read and loaded", async (t) => {
+  const { app } = t.context;
+  await writeFile(join(tmp, "document.js"), "export default (incoming, body) => `hello world`;");
+  const podlet = new Podlet({ name: "test", version: "1.0.0", pathname: "/" });
+  await app.register(plugin, { cwd: tmp, development: true, podlet });
+  // @ts-ignore
+  t.equal(podlet._view(), "hello world", "document.js file loaded and registered as podlet view");
+  await rm(tmp, { recursive: true, force: true });
+});
+
+test("Basic typescript document template is read and loaded", async (t) => {
+  const { app } = t.context;
+  await writeFile(join(tmp, "document.ts"), "export default (incoming, body) => `hello world`;");
+  const podlet = new Podlet({ name: "test", version: "1.0.0", pathname: "/" });
+  await app.register(plugin, { cwd: tmp, development: true, podlet });
+  // @ts-ignore
+  t.equal(podlet._view(), "hello world", "document.ts file loaded and registered as podlet view");
+  await rm(tmp, { recursive: true, force: true });
+});


### PR DESCRIPTION
Adds support for Podium document templates via a document.js or .ts file