### PR TITLE
feat: add test server for testing applications

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,10 @@
+import configuration from "../lib/config.js";
+export { build } from "./build.js";
+export { start } from "./start.js";
+export { dev } from "./dev.js";
+export { Core } from "../lib/resolvers/core.js";
+export { Local } from "../lib/resolvers/local.js";
+export { Extensions } from "../lib/resolvers/extensions.js";
+export { State } from "../lib/state.js";
+export { configuration };
+export { TestServer } from "./test.js";

--- a/api/test.js
+++ b/api/test.js
@@ -1,0 +1,138 @@
+import { join } from "path";
+import fastify from "fastify";
+import httpError from "http-errors";
+import esbuild from "esbuild";
+import configuration from "../lib/config.js";
+import { Local } from "../lib/resolvers/local.js";
+import { Core } from "../lib/resolvers/core.js";
+import { Extensions } from "../lib/resolvers/extensions.js";
+import { State } from "../lib/state.js";
+import PathResolver from "../lib/path.js";
+
+/**
+ * Concatenate URL path segments.
+ * @param {...string} segments - URL path segments to concatenate.
+ * @returns {string} - The concatenated URL.
+ */
+const joinURLPathSegments = (...segments) => {
+  return segments.join("/").replace(/[\/]+/g, "/");
+};
+
+export class TestServer {
+  cwd;
+  development;
+  config;
+  state;
+  app;
+  port;
+  address;
+  logger;
+  #resolver;
+
+  static async create({ cwd = process.cwd(), development = false } = {}) {
+    const state = new State({ cwd });
+    state.set("core", await Core.load());
+    state.set("extensions", await Extensions.load({ cwd, development: true }));
+    state.set("local", await Local.load({ cwd, development: true }));
+    const config = await configuration({ cwd, schemas: await state.config() });
+    // @ts-ignore
+    config.set("assets.development", development);
+    return new TestServer({ cwd, development, config, state });
+  }
+
+  constructor({ cwd, development, config, state }) {
+    this.cwd = cwd;
+    this.development = development;
+    this.config = config;
+    this.state = state;
+    this.#resolver = new PathResolver({ cwd, development });
+  }
+
+  async build() {
+    const { cwd, state } = this;
+    const outdir = join(cwd, "dist");
+    const clientOutdir = join(outdir, "client");
+    const contentFilepath = await this.#resolver.resolve("./content");
+    const fallbackFilepath = await this.#resolver.resolve("./fallback");
+    const scriptsFilepath = await this.#resolver.resolve("./scripts");
+    const lazyFilepath = await this.#resolver.resolve("./lazy");
+
+    const entryPoints = [];
+    if (contentFilepath.exists) {
+      entryPoints.push(contentFilepath.path);
+    }
+    if (fallbackFilepath.exists) {
+      entryPoints.push(fallbackFilepath.path);
+    }
+    if (scriptsFilepath.exists) {
+      entryPoints.push(scriptsFilepath.path);
+    }
+    if (lazyFilepath.exists) {
+      entryPoints.push(lazyFilepath.path);
+    }
+
+    await esbuild.build({
+      entryPoints,
+      entryNames: "[name]",
+      bundle: true,
+      format: "esm",
+      outdir: clientOutdir,
+      minify: true,
+      target: ["es2017"],
+      legalComments: `none`,
+      sourcemap: true,
+      plugins: await state.build(),
+    });
+  }
+
+  async setup() {
+    const app = fastify({
+      logger: this.logger || false,
+      ignoreTrailingSlash: true,
+      forceCloseConnections: true,
+    });
+
+    const plugins = await this.state.build();
+    const extensions = this.state.get("extensions");
+    for (const serverPlugin of await this.state.server()) {
+      await app.register(serverPlugin, {
+        cwd: this.cwd,
+        prefix: this.config.get("app.base"),
+        config: this.config,
+        // @ts-ignore
+        podlet: app.podlet,
+        errors: httpError,
+        plugins,
+        extensions,
+      });
+    }
+
+    return app;
+  }
+
+  async start() {
+    this.app = await this.setup();
+    this.address = await this.app.listen({ port: 0, host: "127.0.0.1" });
+    this.port = this.app.server.address().port;
+  }
+
+  async stop() {
+    await this.app?.close();
+  }
+
+  get routes() {
+    const routeObject = {
+      manifest: this.address + joinURLPathSegments(this.config.get("app.base"), this.config.get("podlet.manifest")),
+    };
+
+    if (this.config.get("podlet.content")) {
+        routeObject.content = this.address + joinURLPathSegments(this.config.get("app.base"), this.config.get("podlet.content"));
+    }
+
+    if (this.config.get("podlet.fallback")) {
+        routeObject.fallback = this.address + joinURLPathSegments(this.config.get("app.base"), this.config.get("podlet.fallback"));
+    }
+
+    return routeObject;
+  }
+}

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -135,69 +135,77 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
 
       if (existsSync(contentFilePath)) {
         f.get(f.podlet.content(), async (request, reply) => {
-          const contextConfig = /** @type {FastifyContextConfig} */ (reply.context.config);
-          contextConfig.timing = true;
+          try {
+            const contextConfig = /** @type {FastifyContextConfig} */ (reply.context.config);
+            contextConfig.timing = true;
 
-          if (mode === "ssr-only" || mode === "hydrate") {
-            // import server side component
-            await f.importElement(contentFilePath);
+            if (mode === "ssr-only" || mode === "hydrate") {
+              // import server side component
+              await f.importElement(contentFilePath);
+            }
+
+            const initialState = JSON.stringify(
+              // @ts-ignore
+              (await contentStateFn(request, reply.app.podium.context)) || ""
+            );
+
+            const translations = f.translations ? ` translations='${JSON.stringify(f.translations)}'` : "";
+            const template = `<${name}-content version="${version}" locale='${locale}'${translations} initial-state='${initialState}'></${name}-content>`;
+            const hydrateSupport =
+              mode === "hydrate"
+                ? f.script(`${prefix}/node_modules/lit/experimental-hydrate-support.js`, { dev: true })
+                : "";
+            const markup =
+              mode === "ssr-only"
+                ? f.ssr(template)
+                : mode === "csr-only"
+                ? f.csr("content", template)
+                : f.hydrate("content", template);
+
+            reply.type("text/html; charset=utf-8").send(`${hydrateSupport}${markup}`);
+
+            return reply;
+          } catch (err) {
+            f.log.error(err);
           }
-
-          const initialState = JSON.stringify(
-            // @ts-ignore
-            (await contentStateFn(request, reply.app.podium.context)) || ""
-          );
-
-          const translations = f.translations ? ` translations='${JSON.stringify(f.translations)}'` : "";
-          const template = `<${name}-content version="${version}" locale='${locale}'${translations} initial-state='${initialState}'></${name}-content>`;
-          const hydrateSupport =
-            mode === "hydrate"
-              ? f.script(`${prefix}/node_modules/lit/experimental-hydrate-support.js`, { dev: true })
-              : "";
-          const markup =
-            mode === "ssr-only"
-              ? f.ssr(template)
-              : mode === "csr-only"
-              ? f.csr("content", template)
-              : f.hydrate("content", template);
-
-          reply.type("text/html; charset=utf-8").send(`${hydrateSupport}${markup}`);
-
-          return reply;
         });
       }
 
       if (existsSync(fallbackFilePath)) {
         f.get(f.podlet.fallback(), async (request, reply) => {
-          const contextConfig = /** @type {FastifyContextConfig} */ (reply.context.config);
-          contextConfig.timing = true;
+          try {
+            const contextConfig = /** @type {FastifyContextConfig} */ (reply.context.config);
+            contextConfig.timing = true;
 
-          if (mode === "ssr-only" || mode === "hydrate") {
-            // import server side component
-            await f.importElement(fallbackFilePath);
+            if (mode === "ssr-only" || mode === "hydrate") {
+              // import server side component
+              await f.importElement(fallbackFilePath);
+            }
+
+            const initialState = JSON.stringify(
+              // @ts-ignore
+              (await fallbackStateFn(request, reply.app.podium.context)) || ""
+            );
+
+            const translations = f.translations ? ` translations='${JSON.stringify(f.translations)}'` : "";
+            const template = `<${name}-fallback version="${version}" locale='${locale}'${translations} initial-state='${initialState}'></${name}-fallback>`;
+            const hydrateSupport =
+              mode === "hydrate"
+                ? f.script(`${prefix}/node_modules/lit/experimental-hydrate-support.js`, { dev: true })
+                : "";
+            const markup =
+              mode === "ssr-only"
+                ? f.ssr(template)
+                : mode === "csr-only"
+                ? f.csr("fallback", template)
+                : f.hydrate("fallback", template);
+
+            reply.type("text/html; charset=utf-8").send(`${hydrateSupport}${markup}`);
+
+            return reply;
+          } catch (err) {
+            f.log.error(err);
           }
-
-          const initialState = JSON.stringify(
-            // @ts-ignore
-            (await fallbackStateFn(request, reply.app.podium.context)) || ""
-          );
-
-          const translations = f.translations ? ` translations='${JSON.stringify(f.translations)}'` : "";
-          const template = `<${name}-fallback version="${version}" locale='${locale}'${translations} initial-state='${initialState}'></${name}-fallback>`;
-          const hydrateSupport =
-            mode === "hydrate"
-              ? f.script(`${prefix}/node_modules/lit/experimental-hydrate-support.js`, { dev: true })
-              : "";
-          const markup =
-            mode === "ssr-only"
-              ? f.ssr(template)
-              : mode === "csr-only"
-              ? f.csr("fallback", template)
-              : f.hydrate("fallback", template);
-
-          reply.type("text/html; charset=utf-8").send(`${hydrateSupport}${markup}`);
-
-          return reply;
         });
       }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,12 @@
     "./commands": "./commands/index.js",
     "./build": "./commands/build.js",
     "./start": "./commands/start.js",
-    "./dev": "./commands/dev.js"
+    "./dev": "./commands/dev.js",
+    "./api/build": "./api/build.js",
+    "./api/start": "./api/start.js",
+    "./api/dev": "./api/dev.js",
+    "./api": "./api/index.js",
+    "./test": "./api/test.js"
   },
   "scripts": {
     "test": "tap --no-check-coverage --no-coverage-report test/**/*.test.js"

--- a/package.json
+++ b/package.json
@@ -9,15 +9,11 @@
     "./config": "./lib/config.js",
     "./schema": "./lib/config-schema.js",
     "./plugin": "./lib/plugin.js",
-    "./commands": "./commands/index.js",
-    "./build": "./commands/build.js",
-    "./start": "./commands/start.js",
-    "./dev": "./commands/dev.js",
-    "./api/build": "./api/build.js",
-    "./api/start": "./api/start.js",
-    "./api/dev": "./api/dev.js",
-    "./api": "./api/index.js",
-    "./test": "./api/test.js"
+    "./build": "./api/build.js",
+    "./start": "./api/start.js",
+    "./dev": "./api/dev.js",
+    "./test": "./api/test.js",
+    ".": "./api/index.js"
   },
   "scripts": {
     "test": "tap --no-check-coverage --no-coverage-report test/**/*.test.js"


### PR DESCRIPTION
This PR adds a built in test server that can be used to write test tests for podlets

The API surface looks like:

```js
import { TestServer } from "@podium/podlet-server/test";

const server = await TestServer.create();
await server.build();
await server.start();
await server.stop();
```

The server is started on a random port and the applications files such as content.js, fallback.js etc are all read and used as if the server was running in prod.

A larger example using Tap looks like:

```js
import tap from 'tap';
import { TestServer } from "@podium/podlet-server/test";

// start the test server
const server = await TestServer.create();
await server.build();
await server.start();

tap.test('manifest file renders correctly', async (t) => {
    const result = await fetch(server.routes.manifest);
    const body = await result.json();
    body.version = '<replaced>';
    t.matchSnapshot(body);
});

tap.test("teardown", () => {
  await server.stop();
})
```

The developer maintains control over the build/start/stop and config. You could change config values between tests by
starting and stopping the server for each test

```js
import tap from 'tap';
import { TestServer } from "@podium/podlet-server/test";

// start the test server
const server = await TestServer.create();
await server.build();

tap.test('manifest file renders correctly', async (t) => {
    server.config.set("app.base", "/")
    await server.start();
    const result = await fetch(server.routes.content);
    const body = await result.text();
    t.matchSnapshot(body);
    await server.stop();
});
```