### PR TITLE
Fix build script

### DIFF
--- a/api/build.js
+++ b/api/build.js
@@ -66,7 +66,7 @@ export async function build({ state, config, cwd = process.cwd() }) {
 
     const plugins = await state.build();
 
-    // Run code through esbuild first to apply plugins but don't bundle or minify
+    // Run code through esbuild first (to apply plugins and strip types) but don't bundle or minify
     // use esbuild to resolve imports and then run a build with plugins
     await esbuild.build({
       plugins: [
@@ -99,6 +99,7 @@ export async function build({ state, config, cwd = process.cwd() }) {
       entryPoints,
       bundle: true,
       write: false,
+      outdir: ESBUILD_OUTDIR,
     });
 
     // Run output of esbuild through rollup to take advantage of treeshaking etc.


### PR DESCRIPTION
This PR fixes an issue with the build as follows:
When an entrypoint such as content.js includes files in src, Esbuild won't actually process those files when bundle is not set to true. Since we use Esbuild here to strip TS types and apply plugins only, we don't want bundle: true. In other words, there's no setting in Esbuild (as there is in Rollup) that allows you to build a directory of files and maintain their structure. 
My approach here was to use esbuild to resolve the files in the build and then for each file, run an Esbuild to build it from its source location to its destination and strip types and apply plugins. After this, Rollup is used to produce an optimal production build.