### PR TITLE
feat: add auto documentation pages

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -23,6 +23,7 @@ import scriptsPn from "../plugins/scripts.js";
 import ssrPn from "../plugins/ssr.js";
 import csrPn from "../plugins/csr.js";
 import documentPn from "../plugins/document.js";
+import docsPn from "../plugins/docs.js";
 
 const isAbsoluteURL = (pathOrUrl) => {
   const url = new URL(pathOrUrl, "http://local");
@@ -55,7 +56,7 @@ const defaults = {
 
 /**
  * create an intersection type out of fastify instance and its decorated properties
- * @typedef {import("fastify").FastifyInstance & { podlet: any, metrics: any, importElement: function, translations: object, script: function, hydrate: function, ssr: function, csr: function }} FastifyInstance
+ * @typedef {import("fastify").FastifyInstance & { podlet: any, metrics: any, schemas: any, importElement: function, translations: object, script: function, hydrate: function, ssr: function, csr: function }} FastifyInstance
  */
 
 /**
@@ -87,6 +88,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
 
   let podlet;
   let metrics;
+  let schemas;
   /** @type {stateFunction} */
   let contentStateFn = async (req, context) => ({});
   /** @type {stateFunction} */
@@ -130,6 +132,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
       });
       await f.register(validationPn, { prefix, defaults, mappings: { "/": "content.json" }, cwd });
       await f.register(documentPn, { podlet: f.podlet, cwd, development, extensions });
+      await f.register(docsPn, { podlet: f.podlet, cwd, config, extensions });
 
       // routes
 
@@ -213,6 +216,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
 
       podlet = f.podlet;
       metrics = f.metrics;
+      schemas = f.schemas;
     },
     { prefix }
   );
@@ -240,4 +244,5 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
   fastify.decorate("setFallbackState", setFallbackState);
   fastify.decorate("podlet", podlet);
   fastify.decorate("metrics", metrics);
+  fastify.decorate("schemas", schemas);
 });

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -76,7 +76,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
   const locale = config.get("app.locale") || "";
   const lazy = config.get("assets.lazy") || false;
   const scripts = config.get("assets.scripts") || false;
-  const compression = config.get("app.compression") || true;
+  const compression = config.get("app.compression");
   const grace = config.get("app.grace") || 0;
   const timeAllRoutes = config.get("metrics.timing.timeAllRoutes") || true;
   const groupStatusCodes = config.get("metrics.timing.groupStatusCodes") || true;

--- a/plugins/docs.js
+++ b/plugins/docs.js
@@ -1,0 +1,53 @@
+import fp from "fastify-plugin";
+import Configuration from "./docs/handlers/configuration.get.js";
+import Docs from "./docs/handlers/docs.get.js";
+import Routes from "./docs/handlers/routes.get.js";
+
+/**
+ * @typedef {{ podlet: import("@podium/podlet").default, cwd: string, config: import("convict").Config, extensions?: import("../lib/resolvers/extensions").Extensions }} DocumentPluginOptions
+ */
+
+export default fp(async function docsPlugin(
+  fastify,
+  /**@type {DocumentPluginOptions}*/
+  { podlet, cwd, config, extensions }
+) {
+  // @ts-ignore
+  if (config.get("app.development") === true) {
+    const docs = new Docs({ config, extensions });
+    const configuration = new Configuration({ config });
+    
+    function buildUrlPath(path) {
+      return path.replaceAll(/\/+/g, "/");
+    }
+
+    const routeData = {
+      routes: {
+        content: {
+          // @ts-ignore
+          path: buildUrlPath(`/${config.get("app.base")}/${config.get("podlet.content")}`),
+        },
+        manifest: {
+          path: buildUrlPath(`/${config.get("app.base")}/${config.get("podlet.manifest")}`),
+          data: JSON.parse(JSON.stringify(podlet)),
+        },
+        fallback: {
+          path: buildUrlPath(`/${config.get("app.base")}/${config.get("podlet.fallback")}`),
+        },
+      },
+      assets: {
+        content: buildUrlPath(`/${config.get("assets.base")}/client/content.js`),
+        fallback: buildUrlPath(`/${config.get("assets.base")}/client/fallback.js`),
+        scripts: false,
+        lazy: buildUrlPath(`/${config.get("assets.base")}/client/lazy.js`),
+      },
+    };
+    
+    // @ts-ignore
+    const routes = new Routes({ data: routeData, schemas: fastify.schemas });
+
+    fastify.get("/docs", docs.handler.bind(docs));
+    fastify.get("/docs/configuration", configuration.handler.bind(configuration));
+    fastify.get("/docs/routes", routes.handler.bind(routes));
+  }
+});

--- a/plugins/docs.js
+++ b/plugins/docs.js
@@ -2,6 +2,7 @@ import fp from "fastify-plugin";
 import Configuration from "./docs/handlers/configuration.get.js";
 import Docs from "./docs/handlers/docs.get.js";
 import Routes from "./docs/handlers/routes.get.js";
+import Extensions from "./docs/handlers/extensions.get.js";
 
 /**
  * @typedef {{ podlet: import("@podium/podlet").default, cwd: string, config: import("convict").Config, extensions?: import("../lib/resolvers/extensions").Extensions }} DocumentPluginOptions
@@ -45,9 +46,12 @@ export default fp(async function docsPlugin(
     
     // @ts-ignore
     const routes = new Routes({ data: routeData, schemas: fastify.schemas });
+    
+    const exts = new Extensions({ extensions });
 
     fastify.get("/docs", docs.handler.bind(docs));
     fastify.get("/docs/configuration", configuration.handler.bind(configuration));
     fastify.get("/docs/routes", routes.handler.bind(routes));
+    fastify.get("/docs/extensions", exts.handler.bind(exts));
   }
 });

--- a/plugins/docs/handlers/configuration.get.js
+++ b/plugins/docs/handlers/configuration.get.js
@@ -1,0 +1,146 @@
+export default class Configuration {
+  #data;
+
+  constructor({ config }) {
+    this.#data = config.getProperties();
+  }
+
+  createKeyValueTable(data) {
+    let tableValues = "";
+    for (const key in data) {
+      tableValues += `<tr><td>${key}</td><td>${data[key]}</td></tr>`;
+    }
+    return `<table style="margin-bottom:10px;">${tableValues}</table>`;
+  }
+
+  createKeyValueTableRow(section, data) {
+    return `<tr><td>${section}</td><td>${data}</td></tr>`;
+  }
+
+  createTable(section, data) {
+    let tableHeaders = "";
+    let tableValues = "";
+
+    for (const key in data) {
+      const value =
+        typeof data[key] === "object" && data[key] !== null ? this.createKeyValueTable(data[key]) : data[key];
+
+      tableHeaders += `<th>${key}</th>`;
+      tableValues += `<td>${value}</td>`;
+    }
+
+    const table = `
+        <table>
+          <caption>${section}</caption>
+          <thead>
+            <tr>${tableHeaders}</tr>
+          </thead>
+          <tbody>
+            <tr>${tableValues}</tr>
+          </tbody>
+        </table>`;
+    return table;
+  }
+
+  async handler(req, reply) {
+    let tables = "";
+    let additionalRows = "";
+
+    for (const key in this.#data) {
+      if (typeof this.#data[key] === "string") {
+        additionalRows += this.createKeyValueTableRow(key, this.#data[key]);
+      } else {
+        tables += this.createTable(key, this.#data[key]);
+      }
+    }
+
+    if (additionalRows) {
+      tables += `
+				<table>
+						<caption>Other</caption>
+						<thead>
+							<tr><th>key</th><th>value</th></tr>
+						</thead>
+						<tbody>
+							${additionalRows}
+						</tbody>
+					</table>
+					`;
+    }
+
+    reply.type("text/html").send(
+      `<!DOCTYPE html>
+			<html lang="en">
+			<head>
+				<meta charset="UTF-8">
+				<meta name="viewport" content="width=device-width, initial-scale=1.0">
+				<title>Configuration</title>
+				<style>
+					body {
+						font-family: Arial, sans-serif;
+						margin: 30px;
+					}
+					table {
+						border-collapse: collapse;
+						width: 100%;
+						margin-bottom: 30px;
+					}
+					th, td {
+						vertical-align: top;
+						text-align: left;
+						padding: 8px;
+						border-bottom: 1px solid #ddd;
+					}
+					th {
+						background-color: #f2f2f2;
+					}
+					caption {
+						text-align: left;
+						font-weight: bold;
+						margin-bottom: 10px;
+					}
+					.breadcrumbs {
+						font-family: Arial, sans-serif;
+						list-style: none;
+						padding: 0;
+						margin: 0;
+						display: flex;
+						flex-wrap: wrap;
+					}
+					.breadcrumbs li {
+						display: flex;
+						align-items: center;
+					}
+					.breadcrumbs li:not(:last-child)::after {
+						content: '/';
+						margin: 0 5px;
+						color: #999;
+					}
+					.breadcrumbs li a {
+						text-decoration: none;
+						color: #3498db;
+					}
+					.breadcrumbs li a:hover {
+						text-decoration: underline;
+					}
+					.breadcrumbs li:last-child a {
+						color: #333;
+						cursor: default;
+					}
+				</style>
+			</head>
+			<body>
+				<h1>Configuration</h1>
+				<nav aria-label="Breadcrumb" style="margin-bottom: 20px;">
+					<ul class="breadcrumbs">
+						<li><a href="/docs">Docs</a></li>
+						<li><a href="#">Configuration</a></li>
+					</ul>
+				</nav>
+				<div>${tables}</div>
+			</body>
+			</html>`
+    );
+		return reply;
+  }
+}

--- a/plugins/docs/handlers/docs.get.js
+++ b/plugins/docs/handlers/docs.get.js
@@ -1,0 +1,40 @@
+export default class Docs {
+  constructor({ config, extensions }) {
+    this.config = config;
+    this.extensions = extensions;
+  }
+  async handler(req, reply) {
+    console.log("docs handler")
+    reply.type("text/html").send(`
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Documentation</title>
+        <style>
+        body {
+          font-family: Arial, sans-serif;
+          margin: 30px;
+        }
+        a {
+          text-decoration: none;
+          color: #3498db;
+        }
+        a:hover {
+          text-decoration: underline;
+        }
+        </style>
+      </head>
+      <body>
+        <h1>Documentation</h1>
+        <ul>
+        <li><a href="/docs/configuration">Configuration</a></li>
+        <li><a href="/docs/routes">Routes</a></li>
+        </ul>
+      </body>
+      </html>
+    `);
+    return reply;
+  }
+}

--- a/plugins/docs/handlers/docs.get.js
+++ b/plugins/docs/handlers/docs.get.js
@@ -28,9 +28,11 @@ export default class Docs {
       </head>
       <body>
         <h1>Documentation</h1>
+        <p>Automatically generated documentation pages for a @podium/podlet-server application.</p>
         <ul>
         <li><a href="/docs/configuration">Configuration</a></li>
         <li><a href="/docs/routes">Routes</a></li>
+        <li><a href="/docs/extensions">Extensions</a></li>
         </ul>
       </body>
       </html>

--- a/plugins/docs/handlers/extensions.get.js
+++ b/plugins/docs/handlers/extensions.get.js
@@ -1,0 +1,114 @@
+export default class Extensions {
+  #data;
+
+  constructor({ extensions }) {
+    this.#data = extensions;
+  }
+
+  createTables(data) {
+    let tables = "";
+
+    for (const [key, value] of data) {
+      tables += `
+          <table>
+            <caption>${key}</caption>
+            <thead>
+              <tr>
+                <th>server</th>
+                <th>config</th>
+                <th>build</th>
+                <th>document</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>${value.server ? "✔" : "✘"}</td>
+                <td>${value.config ? "✔" : "✘"}</td>
+                <td>${value.build ? "✔" : "✘"}</td>
+                <td>${value.document ? "✔" : "✘"}</td>
+              </tr>
+            </tbody>
+          </table>`;
+    }
+
+    return tables;
+  }
+
+  async handler(req, reply) {
+    console.log("data", this.#data);
+    reply.type("text/html").send(
+      `<!DOCTYPE html>
+			<html lang="en">
+			<head>
+				<meta charset="UTF-8">
+				<meta name="viewport" content="width=device-width, initial-scale=1.0">
+				<title>Configuration</title>
+				<style>
+					body {
+						font-family: Arial, sans-serif;
+						margin: 30px;
+					}
+					table {
+						border-collapse: collapse;
+						width: 100%;
+						margin-bottom: 30px;
+					}
+					th, td {
+						vertical-align: top;
+						text-align: left;
+						padding: 8px;
+						border-bottom: 1px solid #ddd;
+					}
+					th {
+						background-color: #f2f2f2;
+					}
+					caption {
+						text-align: left;
+						font-weight: bold;
+						margin-bottom: 10px;
+					}
+					.breadcrumbs {
+						font-family: Arial, sans-serif;
+						list-style: none;
+						padding: 0;
+						margin: 0;
+						display: flex;
+						flex-wrap: wrap;
+					}
+					.breadcrumbs li {
+						display: flex;
+						align-items: center;
+					}
+					.breadcrumbs li:not(:last-child)::after {
+						content: '/';
+						margin: 0 5px;
+						color: #999;
+					}
+					.breadcrumbs li a {
+						text-decoration: none;
+						color: #3498db;
+					}
+					.breadcrumbs li a:hover {
+						text-decoration: underline;
+					}
+					.breadcrumbs li:last-child a {
+						color: #333;
+						cursor: default;
+					}
+				</style>
+			</head>
+			<body>
+				<h1>Extensions</h1>
+				<nav aria-label="Breadcrumb" style="margin-bottom: 20px;">
+					<ul class="breadcrumbs">
+						<li><a href="/docs">Docs</a></li>
+						<li><a href="#">Configuration</a></li>
+					</ul>
+				</nav>
+				<div>${this.createTables(this.#data.extensions.entries())}</div>
+			</body>
+			</html>`
+    );
+    return reply;
+  }
+}

--- a/plugins/docs/handlers/routes.get.js
+++ b/plugins/docs/handlers/routes.get.js
@@ -1,0 +1,204 @@
+export default class Routes {
+  #data;
+  #schemas;
+  constructor({ data, schemas }) {
+    this.#data = data;
+    this.#schemas = schemas;
+  }
+
+  buildObjects(schema) {
+    let obj = {};
+    let required = [];
+    const results = [];
+    if (!schema) return results;
+    if (schema.required) required = schema.required;
+    // check top level for object and properties keys
+    if (schema.type === "object" && schema.properties) {
+      for (const [key, value] of Object.entries(schema.properties)) {
+        obj[key] = value;
+      }
+    } else {
+      obj = schema;
+    }
+
+    for (const [key, value] of Object.entries(obj)) {
+      results.push({
+        name: key,
+        required: required.includes(key),
+        description: value.description || "",
+        type: value.type,
+        options: value.enum || [],
+      });
+    }
+
+    return results;
+  }
+
+  buildUrlPath(path) {
+    return path.replaceAll(/\/+/g, "/");
+  }
+
+  createDataTable(caption, data) {
+    if (!data.length) return "";
+    let tableValues = "";
+    for (const { name, required, description, type, options } of data) {
+      tableValues += `
+        <tr>
+          <td>${name}</td>
+          <td>${type}</td>
+          <td>${required}</td>
+          <td>${description}</td>
+          <td>${options.length ? options.join(", ") : ""}</td>
+        </tr>`;
+    }
+    return `
+      <table>
+        <caption>${caption}</caption>
+        <thead>
+          <th>name</th>
+          <th>type</th>
+          <th>required</th>
+          <th>description</th>
+          <th>options</th>
+        </thead>
+        <tbody>${tableValues}</tbody>
+      </table>`;
+  }
+
+  createManifestTable({ name, version, content, fallback, css, js, proxy }) {
+    return `
+      <table>
+        <caption>Manifest</caption>
+        <thead>
+          <th>Name</th>
+          <th>Version</th>
+          <th>Content</th>
+          <th>Fallback</th>
+          <th>CSS</th>
+          <th>JS</th>
+          <th>Proxy</th>
+        </thead>
+        <tbody>
+          <tr>
+            <td>${name}</td>
+            <td>${version}</td>
+            <td>${content}</td>
+            <td>${fallback}</td>
+            <td>${JSON.stringify(css)}</td>
+            <td>${JSON.stringify(js)}</td>
+            <td>${JSON.stringify(proxy)}</td>
+          </tr>
+        </tbody>
+      </table>`;
+  }
+
+  createAssetsTable(data) {
+    let tableValues = "";
+    for (const key in data) {
+      if (!data[key]) tableValues += `<tr><td>${key}</td><td>disabled</td></tr>`;
+      else tableValues += `<tr><td>${key}</td><td><a href="${data[key]}">${data[key]}</a></td></tr>`;
+    }
+    return `<table><thead><th>Name</th><th>Path</th></thead><tbody>${tableValues}</tbody></table>`;
+  }
+
+  async handler(req, reply) {
+    const contentSchema = this.#schemas.get(this.#data.routes.content.path);
+    const fallbackSchema = this.#schemas.get(this.#data.routes.content.path);
+    
+    const contentQuerystringObject = this.buildObjects(contentSchema.querystring);
+    const fallbackQuerystringObject = this.buildObjects(fallbackSchema.querystring);
+    const contentHeadersObject = this.buildObjects(contentSchema.headers);
+    const fallbackHeadersObject = this.buildObjects(fallbackSchema.headers);
+    const contentParamsObject = this.buildObjects(contentSchema.params);
+    const fallbackParamsObject = this.buildObjects(fallbackSchema.params);
+
+    reply.type("text/html").send(`
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Documentation</title>
+        <style>
+        body {
+          font-family: Arial, sans-serif;
+          margin: 30px;
+        }
+        table {
+          border-collapse: collapse;
+          width: 100%;
+          margin-bottom: 30px;
+        }
+        th, td {
+          vertical-align: top;
+          text-align: left;
+          padding: 8px;
+          border-bottom: 1px solid #ddd;
+        }
+        th {
+          background-color: #f2f2f2;
+        }
+        caption {
+          text-align: left;
+          font-weight: bold;
+          margin-bottom: 10px;
+        }
+        .breadcrumbs {
+          font-family: Arial, sans-serif;
+          list-style: none;
+          padding: 0;
+          margin: 0;
+          display: flex;
+          flex-wrap: wrap;
+        }
+        .breadcrumbs li {
+          display: flex;
+          align-items: center;
+        }
+        .breadcrumbs li:not(:last-child)::after {
+          content: '/';
+          margin: 0 5px;
+          color: #999;
+        }
+        a {
+          text-decoration: none;
+          color: #3498db;
+        }
+        a:hover {
+          text-decoration: underline;
+        }
+        .breadcrumbs li:last-child a {
+          color: #333;
+          cursor: default;
+        }
+        </style>
+      </head>
+      <body>
+        <h1>Routes</h1>
+        <nav aria-label="Breadcrumb" style="margin-bottom: 20px;">
+					<ul class="breadcrumbs">
+						<li><a href="/docs">Docs</a></li>
+						<li><a href="#">Routes</a></li>
+					</ul>
+				</nav>
+        <h2>Manifest <a href="${this.#data.routes.manifest.path}">${this.#data.routes.manifest.path}</a></h2>
+        ${this.createManifestTable(this.#data.routes.manifest.data)}
+        
+        <h2>Content <a href="${this.#data.routes.content.path}">${this.#data.routes.content.path}</a></h2>
+        ${this.createDataTable("Headers", contentHeadersObject)}
+        ${this.createDataTable("Query params", contentQuerystringObject)}
+        ${this.createDataTable("URL params", contentParamsObject)}
+        
+        <h2>Fallback <a href="${this.#data.routes.fallback.path}">${this.#data.routes.fallback.path}</a></h2>
+        ${this.createDataTable("Headers", fallbackHeadersObject)}
+        ${this.createDataTable("Query params", fallbackQuerystringObject)}
+        ${this.createDataTable("URL params", fallbackParamsObject)}
+
+        <h2>Assets</h2>
+        ${this.createAssetsTable(this.#data.assets)}
+      </body>
+      </html>
+    `);
+    return reply;
+  }
+}

--- a/plugins/validation.js
+++ b/plugins/validation.js
@@ -54,6 +54,7 @@ export default fp(async function validation(
   });
 
   const logs = [];
+  const schemas = new Map();
 
   /**
    * Hook in as each route is defined and try to load in schema files for that route.
@@ -94,7 +95,10 @@ export default fp(async function validation(
 
     // append schema to route options
     routeOptions.schema = schema;
+    schemas.set(routePath || "/", schema);
   });
+
+  fastify.decorate("schemas", schemas);
 
   fastify.addHook("onReady", () => {
     if (logs.length) {


### PR DESCRIPTION
Creates a series of auto generated documentation pages for the podlet which include information on routes, configuration and loaded extensions.

<img width="1282" alt="Screen Shot 2023-04-20 at 15 24 53" src="https://user-images.githubusercontent.com/1177098/233250497-f5aaed43-2052-4809-967a-6077807f8fff.png">

<img width="1483" alt="Screen Shot 2023-04-20 at 15 25 15" src="https://user-images.githubusercontent.com/1177098/233250552-bb358dd4-769e-43fd-8811-4186f8534ac0.png">

<img width="1495" alt="Screen Shot 2023-04-20 at 15 25 34" src="https://user-images.githubusercontent.com/1177098/233250583-5e299f14-5576-4eeb-8111-099d428efb7c.png">

<img width="1485" alt="Screen Shot 2023-04-20 at 15 21 54" src="https://user-images.githubusercontent.com/1177098/233250439-790c0d37-5626-4cb7-8dad-a5422fd07f51.png">
