### PR TITLE
fix: replace dsd ponyfill with more comprehensive implementation

### DIFF
--- a/api/build.js
+++ b/api/build.js
@@ -6,6 +6,9 @@ import rollupPluginTerser from "@rollup/plugin-terser";
 import { rollup } from "rollup";
 import rollupPluginResolve from "@rollup/plugin-node-resolve";
 import rollupPluginCommonjs from "@rollup/plugin-commonjs";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
 
 /**
  * Builds the project using esbuild.
@@ -65,6 +68,18 @@ export async function build({ state, config, cwd = process.cwd() }) {
     }
 
     const plugins = await state.build();
+
+    // build dsd ponyfill
+    await esbuild.build({
+      entryPoints: [require.resolve("@webcomponents/template-shadowroot/template-shadowroot.js")],
+      bundle: true,
+      format: "esm",
+      outfile: join(CLIENT_OUTDIR, "template-shadowroot.js"),
+      minify: true,
+      target: ["es2017"],
+      legalComments: `none`,
+      sourcemap: false,
+    });
 
     // Run code through esbuild first (to apply plugins and strip types) but don't bundle or minify
     // use esbuild to resolve imports and then run a build with plugins

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -119,7 +119,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
       await f.register(exceptionsPn, { grace: grace });
       await f.register(hydratePn, { appName: name, base: assetBase, development });
       await f.register(csrPn, { appName: name, base: assetBase, development });
-      await f.register(ssrPn);
+      await f.register(ssrPn, { appName: name, base });
       await f.register(importElementPn, { appName: name, development, plugins, cwd });
       await f.register(localePn, { locale, cwd });
       await f.register(metricsPn);
@@ -157,7 +157,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
                 : "";
             const markup =
               mode === "ssr-only"
-                ? f.ssr(template)
+                ? f.ssr("content", template)
                 : mode === "csr-only"
                 ? f.csr("content", template)
                 : f.hydrate("content", template);
@@ -195,7 +195,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
                 : "";
             const markup =
               mode === "ssr-only"
-                ? f.ssr(template)
+                ? f.ssr("fallback", template)
                 : mode === "csr-only"
                 ? f.csr("fallback", template)
                 : f.hydrate("fallback", template);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@rollup/plugin-commonjs": "24.1.0",
     "@rollup/plugin-node-resolve": "15.0.2",
     "@rollup/plugin-terser": "0.4.1",
+    "@webcomponents/template-shadowroot": "^0.2.1",
     "abslog": "2.4.0",
     "ajv": "8.12.0",
     "boxen": "7.0.2",

--- a/plugins/hydrate.js
+++ b/plugins/hydrate.js
@@ -7,24 +7,30 @@ import fp from "fastify-plugin";
 const dsdPolyfill = readFileSync(new URL("../lib/dsd-polyfill.js", import.meta.url), { encoding: "utf8" });
 
 export default fp(async function hydratePlugin(fastify, { appName = "", base = "/", development = false }) {
-  fastify.decorate("hydrate", function hydrate(name, template) {
+  fastify.decorate("hydrate", function hydrate(type, template) {
     // user provided markup, SSR'd
     const ssrMarkup = Array.from(ssr(html`${unsafeHTML(template)}`)).join("");
     // polyfill for browsers that don't support declarative shadow dom
-    const polyfillMarkup = `<script>${dsdPolyfill}</script>`;
+    const polyfillMarkup = `
+    <script type="module">
+    if (!HTMLTemplateElement.prototype.hasOwnProperty("shadowRoot")) {
+      const {hydrateShadowRoots} = await import("${base}/client/template-shadowroot.js");
+      hydrateShadowRoots(document.querySelector("${appName}-${type}"));
+    }
+    </script>`;
 
     if (development) {
       return `
         ${ssrMarkup}
         ${polyfillMarkup}
         <script type="module">
-          import El from '${base}/client/${name}.js';
-          customElements.define("${appName}-${name}",El);
+          import El from "${base}/client/${type}.js";
+          customElements.define("${appName}-${type}",El);
         </script>
       `;
     }
 
     // in production, all scripts are bundled into a single file
-    return `${ssrMarkup}${polyfillMarkup}<script type="module" src="${base}/client/${name}.js"></script>`;
+    return `${ssrMarkup}${polyfillMarkup}<script type="module" src="${base}/client/${type}.js"></script>`;
   });
 });

--- a/plugins/ssr.js
+++ b/plugins/ssr.js
@@ -1,17 +1,20 @@
-import { readFileSync } from "node:fs";
 import { html } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { render } from "@lit-labs/ssr";
 import fp from "fastify-plugin";
 
-const dsdPolyfill = readFileSync(new URL("../lib/dsd-polyfill.js", import.meta.url), { encoding: "utf8" });
-
-export default fp(async function ssrPlugin(fastify) {
-  fastify.decorate("ssr", function ssr(template) {
+export default fp(async function ssrPlugin(fastify, { appName = "", base = "/" }) {
+  fastify.decorate("ssr", function ssr(type, template) {
     // user provided markup, SSR'd
     const ssrMarkup = Array.from(render(html`${unsafeHTML(template)}`)).join("");
     // polyfill for browsers that don't support declarative shadow dom
-    const polyfillMarkup = `<script>${dsdPolyfill}</script>`;
+    const polyfillMarkup = `
+    <script type="module">
+    if (!HTMLTemplateElement.prototype.hasOwnProperty("shadowRoot")) {
+      const {hydrateShadowRoots} = await import("${base}/client/template-shadowroot.js");
+      hydrateShadowRoots(document.querySelector("${appName}-${type}"));
+    }
+    </script>`;
     return `${ssrMarkup}${polyfillMarkup}`;
   });
 });

--- a/test/plugins/plugins-hydrate.test.js
+++ b/test/plugins/plugins-hydrate.test.js
@@ -47,6 +47,6 @@ test("server rendering of a lit element with hydration support", async (t) => {
   t.match(result, `<template shadowroot="open"`, "should contain evidence of shadow dom");
   t.match(result, `<div>hello world</div>`, "should contain component rendered markup");
   t.match(result, `hasOwnProperty("shadowRoot")`, "should contain evidence of dsd polyfill");
-  t.match(result, `import El from '/static/client/element.js';`, "should contain client side element import");
+  t.match(result, `import El from "/static/client/element.js";`, "should contain client side element import");
   t.match(result, `customElements.define("custom-element",El);`, "should contain client side element registration");
 });

--- a/test/plugins/plugins-ssr.test.js
+++ b/test/plugins/plugins-ssr.test.js
@@ -39,9 +39,9 @@ afterEach(async (t) => {
 test("server rendering of a lit element", async (t) => {
   const app = /**@type {FastifyInstance}*/ (/**@type {unknown}*/(fastify({ logger: false })));
   await app.register(importElementPn, { cwd: tmp, appName: "custom" });
-  await app.register(plugin);
+  await app.register(plugin, { appName: "custom", base: "/assets" });
   await app.importElement(join(tmp, "element.js"));
-  const result = app.ssr(`<custom-element><custom-element>`);
+  const result = app.ssr("content", `<custom-element><custom-element>`);
   t.match(result, "<!--lit-part", "should contain lit comment tags");
   t.match(result, "<custom-element>", "should contain the correct html tag");
   t.match(result, `<template shadowroot="open"`, "should contain evidence of shadow dom");


### PR DESCRIPTION
Fixes an issue with Safari and FF where the DSD ponyfill was not working correctly and so podlets were displaying a blank page. This was due to my own naive implementation which did not cover nesting. The implementation in this PR is comprehensive but costs 1.2kb. This is ok since it is only shipped if the browser does not support DSD. In practice, this will soon mean only Firefox since Safari has early/experimental support in the latest version and Chrome already fully supports DSD.