### PR TITLE
fix: log host and env on info when app starts

### DIFF
--- a/api/start.js
+++ b/api/start.js
@@ -43,9 +43,10 @@ export async function start({ state, config, cwd = process.cwd() }) {
 
   try {
     const address = await app.listen({ host: "0.0.0.0", port: config.get("app.port") });
+    app.log.info(`Server environment '${config.get("app.env")}', host '${config.get("app.host")}'`);
     return { address, close: app.close.bind(app) };
   } catch (err) {
-    app.log.error(`Unable to start application on port ${config.get("app.port")}`);
+    app.log.error(`Unable to start server on port ${config.get("app.port")}`);
     throw err;
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -23,6 +23,7 @@ export default async function configuration({ schemas = [], cwd = process.cwd() 
   // The expectation is that HOST and NODE_ENV env vars will be set in production
   // @ts-ignore
   const host = config.get("app.host");
+  // @ts-ignore
   const env = config.get("app.env");
 
   // programmatically set defaults for cases


### PR DESCRIPTION
Tweak to logging to make it easier to see which host and env an app is running in