### PR TITLE
fix: ensure metrics are properly streamed. Add additional metrics for import element

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -82,7 +82,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
   let fallbackStateFn = async (req, context) => ({});
 
   // wrap in scoped plugin for prefixed routes to work
-  fastify.register(
+  await fastify.register(
     async (fastify) => {
       // cast fastify to include decorated properties
       const f = /** @type {FastifyInstance} */ (fastify);

--- a/plugins/metrics.js
+++ b/plugins/metrics.js
@@ -14,6 +14,7 @@ export default fp(async function metrics(fastify) {
       stream.on("error", (err) => {
         fastify.log.error(err);
       });
+
       // @ts-ignore
       stream.pipe(fastify.metrics);
     }


### PR DESCRIPTION
This PR:
* fixes a bug where many core metrics were not being consumed by awaiting plugin registration.
* adds additional metrics in the import element module to measure the time taken to bundle and load files