### PR TITLE
feat: inject convict object into extensions schema function

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -1,3 +1,4 @@
+import convict from "convict";
 // Step 1.
 // podlet-server
 // - config = yes
@@ -77,7 +78,7 @@ export class State extends Map {
     }
     if (this.has("extensions")) {
       for (const extensionConfig of this.get("extensions").config) {
-        const schema = await extensionConfig({ cwd: this.cwd, development: this.development });
+        const schema = await extensionConfig({ cwd: this.cwd, development: this.development, convict });
         if (schema) {
           schemas.push(schema);
         }


### PR DESCRIPTION
This PR injects the installed version of Convict into extension schema functions in order for them to be able to register formatters etc.