### PR TITLE
fix: Disable request logging

### DIFF
--- a/api/dev.js
+++ b/api/dev.js
@@ -34,6 +34,7 @@ class DevServer {
       logger: this.logger,
       ignoreTrailingSlash: true,
       forceCloseConnections: true,
+      disableRequestLogging: true,
     });
 
     if (!this.content) {

--- a/api/start.js
+++ b/api/start.js
@@ -21,6 +21,7 @@ export async function start({ state, config, cwd = process.cwd() }) {
           // @ts-ignore
           level: config.get("app.logLevel").toLowerCase(),
         },
+        disableRequestLogging: true,
         ignoreTrailingSlash: true,
       })
     )

--- a/api/test.js
+++ b/api/test.js
@@ -90,6 +90,7 @@ export class TestServer {
       logger: this.logger || false,
       ignoreTrailingSlash: true,
       forceCloseConnections: true,
+      disableRequestLogging: true,
     });
 
     const plugins = await this.state.build();


### PR DESCRIPTION
We've seen that its pretty common to run apps with debug info in prod and Fastify does by default log requests to level info which becomes a lot of logs in a busy server. This turns request logging off.