### PR TITLE
Feature/support rollup plugin file

### DIFF
--- a/api/build.js
+++ b/api/build.js
@@ -1,13 +1,23 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join, dirname, isAbsolute } from "node:path";
+import { join, isAbsolute } from "node:path";
+import { readdir } from "node:fs/promises";
 import esbuild from "esbuild";
 import resolve from "../lib/resolve.js";
 import rollupPluginTerser from "@rollup/plugin-terser";
 import { rollup } from "rollup";
 import rollupPluginResolve from "@rollup/plugin-node-resolve";
 import rollupPluginCommonjs from "@rollup/plugin-commonjs";
+import typescriptPlugin from '@rollup/plugin-typescript';
 import { createRequire } from "node:module";
 import { getLinguiConfig, linguiCompile } from "../lib/lingui.js";
+
+async function usesTypeScript(cwd) {
+  const hasTsConfig = existsSync(join(cwd, 'tsconfig.json'));
+  if (hasTsConfig) return true;
+
+  const srcFiles = await readdir(join(cwd, 'src'));
+  return srcFiles.some(file => file.endsWith('.ts'));
+}
 
 const require = createRequire(import.meta.url);
 
@@ -196,18 +206,26 @@ export async function build({ state, config, cwd = process.cwd() }) {
           outfile = SCRIPTS_FINAL;
         }
 
+        const isUsingTypeScript = await usesTypeScript(cwd);
+        const rollupPlugins = [
+          rollupPluginResolve({ preferBuiltins: true }),
+          rollupPluginCommonjs({ include: /node_modules/ }),
+          rollupPluginTerser({ format: { comments: false } }),
+        ];
+
+        if (isUsingTypeScript) {
+          rollupPlugins.unshift(typescriptPlugin({ tsconfig: join(cwd, 'tsconfig.json') }));
+        }
+
         rollupConfig.push({
           inlineDynamicImports: true,
           input,
           output: {
             file: outfile,
             format: "es",
+            sourcemap: true,
           },
-          plugins: [
-            rollupPluginResolve(),
-            rollupPluginCommonjs({ include: /node_modules/ }),
-            rollupPluginTerser({ format: { comments: false } }),
-          ],
+          plugins: rollupPlugins,
         });
       }
       return rollupConfig;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@rollup/plugin-commonjs": "25.0.0",
     "@rollup/plugin-node-resolve": "15.0.2",
     "@rollup/plugin-terser": "0.4.3",
-    "@rollup/plugin-typescript": "^11.1.0",
     "@webcomponents/template-shadowroot": "^0.2.1",
     "abslog": "2.4.0",
     "ajv": "8.12.0",
@@ -64,7 +63,6 @@
     "pino": "8.14.1",
     "pino-pretty": "10.0.0",
     "rollup": "3.23.0",
-    "tslib": "^2.5.0",
     "semver": "7.5.1",
     "yargs": "17.7.2"
   },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@rollup/plugin-commonjs": "25.0.0",
     "@rollup/plugin-node-resolve": "15.0.2",
     "@rollup/plugin-terser": "0.4.3",
+    "@rollup/plugin-typescript": "^11.1.0",
     "@webcomponents/template-shadowroot": "^0.2.1",
     "abslog": "2.4.0",
     "ajv": "8.12.0",
@@ -63,6 +64,7 @@
     "pino": "8.14.1",
     "pino-pretty": "10.0.0",
     "rollup": "3.23.0",
+    "tslib": "^2.5.0",
     "semver": "7.5.1",
     "yargs": "17.7.2"
   },


### PR DESCRIPTION
Adds support for users having their own rollup file in root named rollup-plugins.js.

It should look something like this

```javascript
// rollup-plugins.js
import typescript from '@rollup/plugin-typescript';
import { join, dirname } from 'path';
import { fileURLToPath } from 'url';

const __filename = fileURLToPath(import.meta.url);
const __dirname = dirname(__filename);

export default [
  typescript({ tsconfig: join(__dirname, 'tsconfig.json') }),
  // ...additional plugins
];
```

This has been confirmed to work locally with https://github.schibsted.io/finn/advertising-podlet. 