### PR TITLE
fix: attempt at fixing memory leak issue

### DIFF
--- a/api/build.js
+++ b/api/build.js
@@ -6,7 +6,7 @@ import rollupPluginTerser from "@rollup/plugin-terser";
 import { rollup } from "rollup";
 import rollupPluginResolve from "@rollup/plugin-node-resolve";
 import rollupPluginCommonjs from "@rollup/plugin-commonjs";
-import typescriptPlugin from '@rollup/plugin-typescript';
+import typescriptPlugin from "@rollup/plugin-typescript";
 import { createRequire } from "node:module";
 import { getLinguiConfig, linguiCompile } from "../lib/lingui.js";
 
@@ -203,8 +203,8 @@ export async function build({ state, config, cwd = process.cwd() }) {
           rollupPluginTerser({ format: { comments: false } }),
         ];
 
-        if (existsSync(join(cwd, 'tsconfig.json'))) {
-          rollupPlugins.unshift(typescriptPlugin({ tsconfig: join(cwd, 'tsconfig.json') }));
+        if (existsSync(join(cwd, "tsconfig.json"))) {
+          rollupPlugins.unshift(typescriptPlugin({ tsconfig: join(cwd, "tsconfig.json") }));
         }
 
         rollupConfig.push({

--- a/commands/start.js
+++ b/commands/start.js
@@ -29,8 +29,8 @@ export const handler = async (argv) => {
 
   const state = new State({ cwd });
   state.set("core", await Core.load());
-  state.set("extensions", await Extensions.load({ cwd, development: true }));
-  state.set("local", await Local.load({ cwd, development: true }));
+  state.set("extensions", await Extensions.load({ cwd, development: false }));
+  state.set("local", await Local.load({ cwd, development: false }));
 
   const config = await configuration({ cwd, schemas: await state.config() });
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -60,7 +60,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
   const fallback = config.get("podlet.fallback") || "";
   const development = config.get("app.development") || false;
   const version = config.get("podlet.version") || null;
-  const locale = config.get("app.locale") || "";
+  const locale = config.get("app.locale") || "en";
   const lazy = config.get("assets.lazy") || false;
   const scripts = config.get("assets.scripts") || false;
   const compression = config.get("app.compression");
@@ -119,7 +119,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
       });
       await f.register(validationPn, { prefix, defaults, mappings: { "/": "content.json" }, cwd });
       await f.register(documentPn, { podlet: f.podlet, cwd, development, extensions });
-      await f.register(docsPn, { podlet: f.podlet, cwd, config, extensions });
+      await f.register(docsPn, { podlet: f.podlet, config, extensions });
 
       // routes
       if (existsSync(contentFilePath)) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     ".": "./api/index.js"
   },
   "scripts": {
-    "test": "tap --no-check-coverage --no-coverage-report test/**/*.test.js"
+    "test": "tap --no-check-coverage --no-coverage-report test/**/**/*.test.js",
+    "t": "tap --no-check-coverage --no-coverage-report"
   },
   "keywords": [],
   "author": "",

--- a/plugins/docs.js
+++ b/plugins/docs.js
@@ -11,13 +11,13 @@ import Extensions from "./docs/handlers/extensions.get.js";
 export default fp(async function docsPlugin(
   fastify,
   /**@type {DocumentPluginOptions}*/
-  { podlet, cwd, config, extensions }
+  { podlet, config, extensions }
 ) {
   // @ts-ignore
   if (config.get("app.development") === true) {
     const docs = new Docs({ config, extensions });
     const configuration = new Configuration({ config });
-    
+
     function buildUrlPath(path) {
       return path.replaceAll(/\/+/g, "/");
     }
@@ -43,10 +43,10 @@ export default fp(async function docsPlugin(
         lazy: buildUrlPath(`/${config.get("assets.base")}/client/lazy.js`),
       },
     };
-    
+
     // @ts-ignore
     const routes = new Routes({ data: routeData, schemas: fastify.schemas });
-    
+
     const exts = new Extensions({ extensions });
 
     fastify.get("/docs", docs.handler.bind(docs));

--- a/test/api/start.test.js
+++ b/test/api/start.test.js
@@ -11,7 +11,7 @@ import { Local } from "../../lib/resolvers/local.js";
 import { Core } from "../../lib/resolvers/core.js";
 import { State } from "../../lib/state.js";
 
-const tmp = join(tmpdir(), "./api.test.js");
+const tmp = join(tmpdir(), "./start.test.js");
 
 async function setupConfig({ cwd }) {
   const state = new State({ cwd });


### PR DESCRIPTION
Use file hashes rather than date to cache bust. This is done in an attempt to avoid a bunch of simultaneous import of deps making the cache grow too large. 