### PR TITLE
fix: Do not load language file on each request

### DIFF
--- a/plugins/locale.js
+++ b/plugins/locale.js
@@ -12,20 +12,22 @@ export default fp(async function locale(fastify, { cwd = process.cwd(), locale =
 
   const localeFilePath = join(cwd, "locales", locale) + compiledFileExtension;
 
-  fastify.decorate("readTranslations", async () => {
-    try {
-      const { messages } = await import(`${localeFilePath}?s=${Date.now()}`);
-      fastify.log.debug(`🌏 ${chalk.magenta("translations")}: loaded file "${localeFilePath}" for locale "${locale}"`);
+  let msgs = {};
 
-      return messages;
-    } catch (err) {
-      try {
-        await fs.promises.access(localeFilePath, fs.F_OK);
-        fastify.log.error(`Error reading translation file: ${localeFilePath}`, err);
-        return;
-      } catch {
-        return;
-      }
+  try {
+    const { messages } = await import(`${localeFilePath}?s=${Date.now()}`);
+    fastify.log.debug(`🌏 ${chalk.magenta("translations")}: loaded file "${localeFilePath}" for locale "${locale}"`);
+    msgs = messages;
+  } catch (err) {
+    try {
+      await fs.promises.access(localeFilePath, fs.F_OK);
+      fastify.log.error(`Error reading translation file: ${localeFilePath}`, err);
+    } catch {
+      // eat error
     }
+  }
+
+  fastify.decorate("readTranslations", async () => {
+    return msgs;
   });
 });


### PR DESCRIPTION
This moves dynamic loading of language files from pr request to start on the server. Loading these files through the import loading algorithm is pretty expensive on each request when not needed.