### PR TITLE
fix: remove leaky unsafeHtml usage

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import fp from "fastify-plugin";
 import resolve from "./resolve.js";
 import { existsSync } from "node:fs";
+import { writeFile, unlink } from "node:fs/promises";
 
 // plugins
 import assetsPn from "../plugins/assets.js";
@@ -71,7 +72,9 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
 
   const assetBase = isAbsoluteURL(base) ? base : joinURLPathSegments(prefix, base);
   const contentFilePath = await resolve(join(cwd, "./content.js"));
+  const contentTemplatePath = await resolve(join(cwd, "./content-tmpl.js"));
   const fallbackFilePath = await resolve(join(cwd, "./fallback.js"));
+  const fallbackTemplatePath = await resolve(join(cwd, "./fallback-tmpl.js"));
 
   let podlet;
   let metrics;
@@ -123,6 +126,20 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
 
       // routes
       if (existsSync(contentFilePath)) {
+
+        // write the content file template to tmp dir for import
+        await writeFile(contentTemplatePath, `
+          import { html } from "lit";
+          export default (version, locale, translations, initialState) => html\`<${name}-content version='\${version}' locale='\${locale}' translations='\${translations}' initial-state='\${initialState}'></${name}-content>\`
+        `);
+
+        // import content template file
+        const { default: ssrContentTemplate } = await import(contentTemplatePath);
+        const csrContentTemplate = (translations, initialState) => `<${name}-content version='${version}' locale='${locale}' translations='${translations}' initial-state='${initialState}'></${name}-content>`;
+
+        // unlink content template file
+        await unlink(contentTemplatePath);
+
         f.get(f.podlet.content(), async (request, reply) => {
           try {
             const contextConfig = /** @type {FastifyContextConfig} */ (reply.context.config);
@@ -140,18 +157,17 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
 
             const messages = await f.readTranslations();
 
-            const translations = messages ? ` translations='${JSON.stringify(messages)}'` : "";
-            const template = `<${name}-content version="${version}" locale='${locale}'${translations} initial-state='${initialState}'></${name}-content>`;
+            const translations = messages ? JSON.stringify(messages) : "";
             const hydrateSupport =
               mode === "hydrate"
                 ? f.script(`${prefix}/node_modules/lit/experimental-hydrate-support.js`, { dev: true })
                 : "";
             const markup =
               mode === "ssr-only"
-                ? f.ssr("content", template)
+                ? f.ssr("content", ssrContentTemplate(version, locale, translations, initialState))
                 : mode === "csr-only"
-                ? f.csr("content", template)
-                : f.hydrate("content", template);
+                ? f.csr("content", csrContentTemplate(translations, initialState))
+                : f.hydrate("content", ssrContentTemplate(version, locale, translations, initialState));
 
             reply.type("text/html; charset=utf-8").send(`${hydrateSupport}${markup}`);
 
@@ -163,6 +179,20 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
       }
 
       if (existsSync(fallbackFilePath)) {
+
+        // write the fallback file template to tmp dir for import
+        await writeFile(fallbackTemplatePath, `
+          import { html } from "lit";
+          export default (version, locale, translations, initialState) => html\`<${name}-fallback version='\${version}' locale='\${locale}' translations='\${translations}' initial-state='\${initialState}'></${name}-fallback>\`
+        `);
+
+        // import fallback template file
+        const { default: ssrFallbackTemplate } = await import(fallbackTemplatePath);
+        const csrFallbackTemplate = (translations, initialState) => `<${name}-fallback version='${version}' locale='${locale}' translations='${translations}' initial-state='${initialState}'></${name}-fallback>`;
+
+        // unlink fallback template file
+        await unlink(fallbackTemplatePath);
+
         f.get(f.podlet.fallback(), async (request, reply) => {
           try {
             const contextConfig = /** @type {FastifyContextConfig} */ (reply.context.config);
@@ -180,18 +210,17 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
 
             const messages = await f.readTranslations();
 
-            const translations = messages ? ` translations='${JSON.stringify(messages)}'` : "";
-            const template = `<${name}-fallback version="${version}" locale='${locale}'${translations} initial-state='${initialState}'></${name}-fallback>`;
+            const translations = messages ? JSON.stringify(messages) : "";
             const hydrateSupport =
               mode === "hydrate"
                 ? f.script(`${prefix}/node_modules/lit/experimental-hydrate-support.js`, { dev: true })
                 : "";
             const markup =
               mode === "ssr-only"
-                ? f.ssr("fallback", template)
+                ? f.ssr("fallback", ssrFallbackTemplate(version, locale, translations, initialState))
                 : mode === "csr-only"
-                ? f.csr("fallback", template)
-                : f.hydrate("fallback", template);
+                ? f.csr("fallback", csrFallbackTemplate(translations, initialState))
+                : f.hydrate("fallback", ssrFallbackTemplate(version, locale, translations, initialState));
 
             reply.type("text/html; charset=utf-8").send(`${hydrateSupport}${markup}`);
 

--- a/plugins/hydrate.js
+++ b/plugins/hydrate.js
@@ -1,15 +1,10 @@
-import { readFileSync } from "node:fs";
-import { html } from "lit";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { render as ssr } from "@lit-labs/ssr";
 import fp from "fastify-plugin";
-
-const dsdPolyfill = readFileSync(new URL("../lib/dsd-polyfill.js", import.meta.url), { encoding: "utf8" });
 
 export default fp(async function hydratePlugin(fastify, { appName = "", base = "/", development = false }) {
   fastify.decorate("hydrate", function hydrate(type, template) {
     // user provided markup, SSR'd
-    const ssrMarkup = Array.from(ssr(html`${unsafeHTML(template)}`)).join("");
+    const ssrMarkup = Array.from(ssr(template)).join("");
     // polyfill for browsers that don't support declarative shadow dom
     const polyfillMarkup = `
     <script type="module">

--- a/plugins/ssr.js
+++ b/plugins/ssr.js
@@ -1,12 +1,10 @@
-import { html } from "lit";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { render } from "@lit-labs/ssr";
 import fp from "fastify-plugin";
 
 export default fp(async function ssrPlugin(fastify, { appName = "", base = "/" }) {
   fastify.decorate("ssr", function ssr(type, template) {
     // user provided markup, SSR'd
-    const ssrMarkup = Array.from(render(html`${unsafeHTML(template)}`)).join("");
+    const ssrMarkup = Array.from(render(template)).join("");
     // polyfill for browsers that don't support declarative shadow dom
     const polyfillMarkup = `
     <script type="module">

--- a/test/plugins/plugins-hydrate.test.js
+++ b/test/plugins/plugins-hydrate.test.js
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { test, beforeEach, afterEach } from "tap";
 import fastify from "fastify";
+import { html } from "lit";
 import importElementPn from "../../plugins/import-element.js";
 import plugin from "../../plugins/hydrate.js";
 import { execSync } from "node:child_process";
@@ -41,7 +42,7 @@ test("server rendering of a lit element with hydration support", async (t) => {
   await app.register(importElementPn, { cwd: tmp, appName: "custom" });
   await app.register(plugin, { appName: "custom", base: "/static", development: true });
   await app.importElement(join(tmp, "element.js"));
-  const result = app.hydrate("element", `<custom-element><custom-element>`);
+  const result = app.hydrate("element", html`<custom-element><custom-element>`);
   t.match(result, "<!--lit-part", "should contain lit comment tags");
   t.match(result, "<custom-element>", "should contain the correct html tag");
   t.match(result, `<template shadowroot="open"`, "should contain evidence of shadow dom");

--- a/test/plugins/plugins-ssr.test.js
+++ b/test/plugins/plugins-ssr.test.js
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { test, beforeEach, afterEach } from "tap";
 import fastify from "fastify";
+import { html } from "lit";
 import importElementPn from "../../plugins/import-element.js";
 import plugin from "../../plugins/ssr.js";
 import { execSync } from "node:child_process";
@@ -41,7 +42,7 @@ test("server rendering of a lit element", async (t) => {
   await app.register(importElementPn, { cwd: tmp, appName: "custom" });
   await app.register(plugin, { appName: "custom", base: "/assets" });
   await app.importElement(join(tmp, "element.js"));
-  const result = app.ssr("content", `<custom-element><custom-element>`);
+  const result = app.ssr("content", html`<custom-element><custom-element>`);
   t.match(result, "<!--lit-part", "should contain lit comment tags");
   t.match(result, "<custom-element>", "should contain the correct html tag");
   t.match(result, `<template shadowroot="open"`, "should contain evidence of shadow dom");


### PR DESCRIPTION
To avoid using unsafeHtml, this PR writes the template to disk as a function that returns a Lit html template literal with the content and fallback element names hard coded. These content and fallback templates are written to disk at app start, read back in and then immediately deleted from disk.