### PR TITLE
fix: replace unsafeHtml with unsafeStatic for tag names

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import fp from "fastify-plugin";
 import resolve from "./resolve.js";
 import { existsSync } from "node:fs";
+import {html, unsafeStatic, literal} from 'lit/static-html.js';
 
 // plugins
 import assetsPn from "../plugins/assets.js";
@@ -123,6 +124,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
 
       // routes
       if (existsSync(contentFilePath)) {
+        const tag = unsafeStatic(`${name}-content`);
         f.get(f.podlet.content(), async (request, reply) => {
           try {
             const contextConfig = /** @type {FastifyContextConfig} */ (reply.context.config);
@@ -140,8 +142,10 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
 
             const messages = await f.readTranslations();
 
-            const translations = messages ? ` translations='${JSON.stringify(messages)}'` : "";
-            const template = `<${name}-content version="${version}" locale='${locale}'${translations} initial-state='${initialState}'></${name}-content>`;
+            const translations = messages ? JSON.stringify(messages) : "";
+
+            // includes ${null} hack for SSR. See https://github.com/lit/lit/issues/2246
+            const template = html`<${tag} version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${tag}>${null} `;
             const hydrateSupport =
               mode === "hydrate"
                 ? f.script(`${prefix}/node_modules/lit/experimental-hydrate-support.js`, { dev: true })
@@ -150,7 +154,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
               mode === "ssr-only"
                 ? f.ssr("content", template)
                 : mode === "csr-only"
-                ? f.csr("content", template)
+                ? f.csr("content", `<${name}-content version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${name}-content>`)
                 : f.hydrate("content", template);
 
             reply.type("text/html; charset=utf-8").send(`${hydrateSupport}${markup}`);
@@ -163,6 +167,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
       }
 
       if (existsSync(fallbackFilePath)) {
+        const tag = unsafeStatic(`${name}-fallback`);
         f.get(f.podlet.fallback(), async (request, reply) => {
           try {
             const contextConfig = /** @type {FastifyContextConfig} */ (reply.context.config);
@@ -180,8 +185,8 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
 
             const messages = await f.readTranslations();
 
-            const translations = messages ? ` translations='${JSON.stringify(messages)}'` : "";
-            const template = `<${name}-fallback version="${version}" locale='${locale}'${translations} initial-state='${initialState}'></${name}-fallback>`;
+            const translations = messages ? JSON.stringify(messages) : "";
+            const template = html`<${tag} version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${tag}>${null} `;
             const hydrateSupport =
               mode === "hydrate"
                 ? f.script(`${prefix}/node_modules/lit/experimental-hydrate-support.js`, { dev: true })
@@ -190,7 +195,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
               mode === "ssr-only"
                 ? f.ssr("fallback", template)
                 : mode === "csr-only"
-                ? f.csr("fallback", template)
+                ? f.csr("fallback", `<${name}-fallback version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${name}-fallback>`)
                 : f.hydrate("fallback", template);
 
             reply.type("text/html; charset=utf-8").send(`${hydrateSupport}${markup}`);

--- a/plugins/hydrate.js
+++ b/plugins/hydrate.js
@@ -1,15 +1,10 @@
-import { readFileSync } from "node:fs";
-import { html } from "lit";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { render as ssr } from "@lit-labs/ssr";
 import fp from "fastify-plugin";
-
-const dsdPolyfill = readFileSync(new URL("../lib/dsd-polyfill.js", import.meta.url), { encoding: "utf8" });
 
 export default fp(async function hydratePlugin(fastify, { appName = "", base = "/", development = false }) {
   fastify.decorate("hydrate", function hydrate(type, template) {
     // user provided markup, SSR'd
-    const ssrMarkup = Array.from(ssr(html`${unsafeHTML(template)}`)).join("");
+    const ssrMarkup = Array.from(ssr(template)).join("");
     // polyfill for browsers that don't support declarative shadow dom
     const polyfillMarkup = `
     <script type="module">

--- a/plugins/ssr.js
+++ b/plugins/ssr.js
@@ -1,12 +1,10 @@
-import { html } from "lit";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { render } from "@lit-labs/ssr";
 import fp from "fastify-plugin";
 
 export default fp(async function ssrPlugin(fastify, { appName = "", base = "/" }) {
   fastify.decorate("ssr", function ssr(type, template) {
     // user provided markup, SSR'd
-    const ssrMarkup = Array.from(render(html`${unsafeHTML(template)}`)).join("");
+    const ssrMarkup = Array.from(render(template)).join("");
     // polyfill for browsers that don't support declarative shadow dom
     const polyfillMarkup = `
     <script type="module">

--- a/test/plugins/plugins-hydrate.test.js
+++ b/test/plugins/plugins-hydrate.test.js
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { test, beforeEach, afterEach } from "tap";
 import fastify from "fastify";
+import { html } from "lit";
 import importElementPn from "../../plugins/import-element.js";
 import plugin from "../../plugins/hydrate.js";
 import { execSync } from "node:child_process";
@@ -41,7 +42,7 @@ test("server rendering of a lit element with hydration support", async (t) => {
   await app.register(importElementPn, { cwd: tmp, appName: "custom" });
   await app.register(plugin, { appName: "custom", base: "/static", development: true });
   await app.importElement(join(tmp, "element.js"));
-  const result = app.hydrate("element", `<custom-element><custom-element>`);
+  const result = app.hydrate("element", html`<custom-element><custom-element>`);
   t.match(result, "<!--lit-part", "should contain lit comment tags");
   t.match(result, "<custom-element>", "should contain the correct html tag");
   t.match(result, `<template shadowroot="open"`, "should contain evidence of shadow dom");

--- a/test/plugins/plugins-ssr.test.js
+++ b/test/plugins/plugins-ssr.test.js
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { test, beforeEach, afterEach } from "tap";
 import fastify from "fastify";
+import { html } from "lit";
 import importElementPn from "../../plugins/import-element.js";
 import plugin from "../../plugins/ssr.js";
 import { execSync } from "node:child_process";
@@ -41,7 +42,7 @@ test("server rendering of a lit element", async (t) => {
   await app.register(importElementPn, { cwd: tmp, appName: "custom" });
   await app.register(plugin, { appName: "custom", base: "/assets" });
   await app.importElement(join(tmp, "element.js"));
-  const result = app.ssr("content", `<custom-element><custom-element>`);
+  const result = app.ssr("content", html`<custom-element><custom-element>`);
   t.match(result, "<!--lit-part", "should contain lit comment tags");
   t.match(result, "<custom-element>", "should contain the correct html tag");
   t.match(result, `<template shadowroot="open"`, "should contain evidence of shadow dom");


### PR DESCRIPTION
This PR uses unsafeStatic to define tag names for content and fallback elements instead of running everything through unsafeHtml on every request. Not 100% sure if this will solve the memory leak but seems like a promising approach.

Some issues with using Lit static utils and SSR but have used the recommended workaround
https://github.com/lit/lit/issues/2246