### PR TITLE
fix: ensure url paths have correct number of slash characters

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -148,7 +148,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
             const template = html`<${tag} version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${tag}>${null} `;
             const hydrateSupport =
               mode === "hydrate"
-                ? f.script(`${prefix}/node_modules/lit/experimental-hydrate-support.js`, { dev: true })
+                ? f.script(joinURLPathSegments(`${prefix}/node_modules/lit/experimental-hydrate-support.js`), { dev: true })
                 : "";
             const markup =
               mode === "ssr-only"
@@ -189,7 +189,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
             const template = html`<${tag} version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${tag}>${null} `;
             const hydrateSupport =
               mode === "hydrate"
-                ? f.script(`${prefix}/node_modules/lit/experimental-hydrate-support.js`, { dev: true })
+                ? f.script(joinURLPathSegments(`${prefix}/node_modules/lit/experimental-hydrate-support.js`), { dev: true })
                 : "";
             const markup =
               mode === "ssr-only"

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -148,7 +148,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
             const template = html`<${tag} version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${tag}>${null} `;
             const hydrateSupport =
               mode === "hydrate"
-                ? f.script(joinURLPathSegments(`${prefix}/node_modules/lit/experimental-hydrate-support.js`), { dev: true })
+                ? f.script(joinURLPathSegments(prefix, 'node_modules/lit/experimental-hydrate-support.js'), { dev: true })
                 : "";
             const markup =
               mode === "ssr-only"
@@ -189,7 +189,7 @@ export default fp(async function (fastify, { prefix = "/", extensions, cwd = pro
             const template = html`<${tag} version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${tag}>${null} `;
             const hydrateSupport =
               mode === "hydrate"
-                ? f.script(joinURLPathSegments(`${prefix}/node_modules/lit/experimental-hydrate-support.js`), { dev: true })
+              ? f.script(joinURLPathSegments(prefix, 'node_modules/lit/experimental-hydrate-support.js'), { dev: true })
                 : "";
             const markup =
               mode === "ssr-only"


### PR DESCRIPTION
This was causing an issue where if the app was running with an app.base path of / then url references to hydrate support included two leading / characters which broke things. This PR runs the url path through a function to ensure all / characters are singular.