### PR TITLE
fix: refactor file watching and ws out of plugins

### DIFF
--- a/api/dev.js
+++ b/api/dev.js
@@ -1,31 +1,177 @@
-import { readFileSync, mkdirSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import chokidar from "chokidar";
-import { context } from "esbuild";
 import pino from "pino";
 import fastify from "fastify";
 import httpError from "http-errors";
 import PathResolver from "../lib/path.js";
-import chalk from "chalk";
-import boxen from "boxen";
-import kill from "kill-port";
-// import { createRequire } from "node:module";
+import { WebSocketServer } from "ws";
 import { getLinguiConfig } from "../lib/lingui-config.js";
 import { linguiExtract, linguiCompile } from "../lib/lingui.js";
+import { joinURLPathSegments } from "../lib/utils.js";
 
-// const require = createRequire(import.meta.url);
-const { version } = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), { encoding: "utf8" }));
+function debounce(func, wait) {
+  let timeout;
+  return function executedFunction(...args) {
+    const later = () => {
+      clearTimeout(timeout);
+      func(...args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+}
 
-class DevServer {
-  constructor({ cwd, config, logger, state, content = false }) {
+export class DevServer {
+  /** @type {string} */
+  cwd;
+
+  /** @type {import("convict").Config} */
+  config;
+
+  /** @type {import("pino").BaseLogger} */
+  logger;
+
+  /** @type {import("../lib/state.js").State} */
+  state;
+
+  /** @type {boolean} */
+  content;
+
+  /** @type {import("fastify").FastifyInstance} */
+  app;
+
+  /** @type {chokidar.FSWatcher} */
+  sWatcher;
+
+  /** @type {import("@lingui/conf").LinguiConfig} */
+  linguiConfig;
+
+  /** @type {WebSocketServer} */
+  websocketServer;
+
+  /** @type {PathResolver} */
+  pathResolver;
+
+  /**
+   *
+   * @param {{ cwd: string, config: import("convict").Config, state: import("../lib/state.js").State, content?: boolean, logger?: import("pino").BaseLogger }} options
+   */
+  constructor({ cwd, config, state, logger }) {
     this.cwd = cwd;
     this.config = config;
-    this.logger = logger;
+    this.logger =
+      logger ||
+      pino({
+        transport: {
+          target: "../lib/pino-dev-transport.js",
+        },
+        // @ts-ignore
+        level: config.get("app.logLevel").toLowerCase(),
+      });
     this.state = state;
-    this.content = content;
+    this.sWatcher = chokidar.watch(
+      [
+        "build.js",
+        "build.ts",
+        "document.js",
+        "document.ts",
+        "server.js",
+        "server.ts",
+        "server/**/*.js",
+        "server/**/*.ts",
+        "config/**/*.json",
+        "config/schema.js",
+        "config/schema.ts",
+        "schemas/**/*.json",
+        "locale/**/*.json",
+        "locales/**/*.po",
+      ],
+      {
+        persistent: true,
+        followSymlinks: false,
+        ignored: /(^|[\/\\])\../, // ignore dotfiles
+        cwd,
+      }
+    );
+    this.sWatcher.on("ready", () => {
+      this.sWatcher.on("add", debounce(this.restart.bind(this), 1000));
+      this.sWatcher.on("change", debounce(this.restart.bind(this), 1000));
+      this.sWatcher.on("unlink", debounce(this.restart.bind(this), 1000));
+    });
+    this.cWatcher = chokidar.watch(
+      [
+        "content.js",
+        "content.ts",
+        "fallback.js",
+        "fallback.ts",
+        "scripts.js",
+        "scripts.ts",
+        "lazy.js",
+        "lazy.ts",
+        "client/**/*.js",
+        "client/**/*.ts",
+        "lib/**/*.js",
+        "lib/**/*.ts",
+        "src/**/*.js",
+        "src/**/*.ts",
+        "locales/**/*.po",
+      ],
+      {
+        persistent: true,
+        followSymlinks: false,
+        ignored: /(^|[\/\\])\../, // ignore dotfiles
+        cwd,
+      }
+    );
+    this.webSocketServer = new WebSocketServer({
+      port: 3925,
+    });
+    /**
+     * @typedef {import("ws").WebSocket & { isAlive: boolean }} WebSocketE
+     */
+
+    this.webSocketServer.on(
+      "connection",
+      /** @param {WebSocketE} ws */
+      (ws) => {
+        this.logger.debug("live reload - server got connection from browser");
+        ws.isAlive = true;
+        ws.on("pong", () => {
+          ws.isAlive = true;
+        });
+        ws.on("error", (error) => {
+          this.logger.debug("live reload - connection to browser errored");
+          this.logger.error(error);
+        });
+      }
+    );
+
+    const pingpong = setInterval(() => {
+      this.webSocketServer.clients.forEach((client) => {
+        // Typescript casting dance to add the isAlive property to WebSocket
+        const c = /** @type {WebSocketE} */ (client);
+        if (c.isAlive === false) return c.terminate();
+        c.isAlive = false;
+        c.ping();
+      });
+    }, 30000);
+
+    this.cWatcher.on("close", function close() {
+      clearInterval(pingpong);
+    });
+
+    this.pathResolver = new PathResolver({ development: true, cwd });
   }
 
-  async setup() {
+  async #setup() {
+    // extract in case translations were added
+    await linguiExtract({ linguiConfig: this.linguiConfig, cwd: this.cwd, hideStats: true });
+    // compile in case a .po file changed
+    await linguiCompile({ linguiConfig: this.linguiConfig, config: this.config });
+
+    await this.state.get("local").reload();
+
     const app = fastify({
       logger: this.logger,
       ignoreTrailingSlash: true,
@@ -33,14 +179,15 @@ class DevServer {
       disableRequestLogging: true,
     });
 
-    if (!this.content) {
+    const contentFile = await this.pathResolver.resolve("./content");
+    if (!contentFile.exists) {
       app.get("/", (request, reply) => {
         reply.redirect(join(this.config.get("app.base"), this.config.get("podlet.manifest")));
       });
     }
 
     // if content file is defined, and content url doesn't resolve to /, redirect to content route
-    if (joinURLPathSegments(this.config.get("app.base"), this.config.get("podlet.content")) !== "/" && this.content) {
+    else if (joinURLPathSegments(this.config.get("app.base"), this.config.get("podlet.content")) !== "/") {
       app.get("/", (request, reply) => {
         reply.redirect(join(this.config.get("app.base"), this.config.get("podlet.content")));
       });
@@ -51,6 +198,7 @@ class DevServer {
     for (const serverPlugin of await this.state.server()) {
       await app.register(serverPlugin, {
         cwd: this.cwd,
+        // @ts-ignore
         prefix: this.config.get("app.base"),
         logger: this.logger,
         config: this.config,
@@ -59,265 +207,31 @@ class DevServer {
         errors: httpError,
         plugins,
         extensions,
+        webSocketServer: this.webSocketServer,
+        clientWatcher: this.cWatcher,
+        serverWatcher: this.sWatcher,
       });
     }
-
-    // TODO: wire this up!
-    app.addHook("onError", async (request, reply, error) => {
-      // console.log("fastify onError hook: disposing of build context", error);
-      this.logger.error(error, "fastify onError hook: disposing of build context");
-      // await buildContext.dispose();
-    });
 
     return app;
   }
 
   async start() {
-    this.app = await this.setup();
+    const linguiConfig = await getLinguiConfig({ config: this.config, cwd: this.cwd });
+    if (linguiConfig) {
+      this.linguiConfig = linguiConfig;
+    }
+    this.app = await this.#setup();
     await this.app.listen({ port: this.config.get("app.port") });
     this.app.log.info({ url: `http://localhost:${this.config.get("app.port")}` }, `Development server listening`);
   }
 
   async restart() {
-    const [app] = await Promise.all([this.setup(), this.app?.close()]);
-    this.app = app;
-    try {
-      await this.app.listen({ port: this.config.get("app.port") });
-    } catch (err) {
-      this.logger.error(err, "Failed to restart server");
-      try {
-        this.logger.trace("Killing port %d", this.config.get("app.port"));
-        await kill(this.config.get("app.port"));
-      } catch (err) {
-        this.logger.error(err, "Failed to kill port %d", this.config.get("app.port"));
-      }
-      this.logger.trace("Attempting to restart server again");
-      await this.app.listen({ port: this.config.get("app.port") });
-    }
+    // clean up any listeners added by plugins
+    this.cWatcher.removeAllListeners();
+    await this.app.close();
+    this.app = await this.#setup();
+    await this.app.listen({ port: this.config.get("app.port") });
+    this.app.log.info({ url: `http://localhost:${this.config.get("app.port")}` }, `Development server listening`);
   }
 }
-
-/**
- * Concatenate URL path segments.
- * @param {...string} segments - URL path segments to concatenate.
- * @returns {string} - The concatenated URL.
- */
-const joinURLPathSegments = (...segments) => {
-  return segments.join("/").replace(/[\/]+/g, "/");
-};
-
-/**
- * Set up a development environment for a Podium Podlet server.
- * @param {object} options - The options for the development environment.
- * @param {import("../lib/state").State} options.state - App state object
- * @param {import("convict").Config} options.config - The podlet configuration.
- * @param {string} [options.cwd=process.cwd()] - The current working directory.
- * @returns {Promise<void>}
- */
-export async function dev({ state, config, cwd = process.cwd() }) {
-  // https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/61750
-  // @ts-ignore
-  config.set("assets.development", true);
-
-  const logger = pino({
-    transport: {
-      target: "../lib/pino-dev-transport.js",
-    },
-    // @ts-ignore
-    level: config.get("app.logLevel").toLowerCase(),
-  });
-
-  // https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/61750
-  // @ts-ignore
-  const resolver = new PathResolver({ cwd, development: config.get("app.development") });
-
-  const OUTDIR = join(cwd, "dist");
-  const CLIENT_OUTDIR = join(OUTDIR, "client");
-
-  logger.debug(`⚙️  ${chalk.magenta("app configuration")}: ${JSON.stringify(config.getProperties())}`);
-
-  // calculate routes from config.get("podlet.content") and config.get("podlet.fallback")
-  const routes = [
-    {
-      name: "manifest",
-      path: "/manifest.json",
-    },
-  ];
-  if (config.get("podlet.content")) {
-    routes.push({ name: "content", path: config.get("podlet.content") });
-  }
-  if (config.get("podlet.fallback")) {
-    // @ts-ignore
-    routes.push({ name: "fallback", path: config.get("podlet.fallback") });
-  }
-
-  // i18n launch setup
-  const linguiConfig = await getLinguiConfig({ config, cwd });
-  if (linguiConfig) {
-    // @ts-ignore
-    await linguiExtract({ linguiConfig, cwd, hideStats: true });
-    // @ts-ignore
-    await linguiCompile({ linguiConfig, config });
-  }
-
-  logger.debug(
-    `📍 ${chalk.magenta("routes")}: ${routes
-      .map((r) => `${r.name} ${chalk.cyan(`${(config.get("app.base") + r.path).replace("//", "/")}`)}`)
-      .join(", ")}`
-  );
-
-  // create dist folder if necessary
-  mkdirSync(join(cwd, "dist"), { recursive: true });
-
-  const clientFiles = [];
-  /** @type {import("../lib/path.js").Resolution} */
-  let CONTENT_FILEPATH;
-  /** @type {import("../lib/path.js").Resolution} */
-  let FALLBACK_FILEPATH;
-
-  async function createBuildContext() {
-    CONTENT_FILEPATH = await resolver.resolve("./content");
-    FALLBACK_FILEPATH = await resolver.resolve("./fallback");
-    const SCRIPTS_FILEPATH = await resolver.resolve("./scripts");
-    const LAZY_FILEPATH = await resolver.resolve("./lazy");
-
-    const entryPoints = [];
-    if (CONTENT_FILEPATH.exists) {
-      entryPoints.push(CONTENT_FILEPATH.path);
-    }
-    if (FALLBACK_FILEPATH.exists) {
-      entryPoints.push(FALLBACK_FILEPATH.path);
-    }
-    if (SCRIPTS_FILEPATH.exists) {
-      entryPoints.push(SCRIPTS_FILEPATH.path);
-    }
-    if (LAZY_FILEPATH.exists) {
-      entryPoints.push(LAZY_FILEPATH.path);
-    }
-
-    for (const entryPoint of entryPoints) {
-      clientFiles.push(join("dist", entryPoint.replace(cwd, "")));
-    }
-
-    const plugins = await state.build();
-    const ctx = await context({
-      entryPoints,
-      entryNames: "[name]",
-      bundle: true,
-      format: "esm",
-      outdir: CLIENT_OUTDIR,
-      minify: true,
-      target: ["es2017"],
-      legalComments: `none`,
-      sourcemap: true,
-      plugins,
-    });
-
-    // Esbuild built in server which provides an SSE endpoint the client can subscribe to
-    // in order to know when to reload the page. Client subscribes with:
-    // new EventSource('http://localhost:6935/esbuild').addEventListener('chang() => { location.reload() });
-    await ctx.serve({ port: 6935 });
-    return ctx;
-  }
-
-  // create an esbuild context object for the client side build so that we
-  // can optimally rebundle whenever files change
-  let buildContext = await createBuildContext();
-
-  // create an array of files that are output by the build process
-
-  logger.debug(`${chalk.green("♻️")}  ${chalk.magenta("bundles built")}: ${clientFiles.join(", ")}`);
-
-  const devServer = new DevServer({
-    logger: logger,
-    cwd,
-    config,
-    state,
-    // @ts-ignore
-    content: CONTENT_FILEPATH.exists,
-  });
-
-  // Chokidar provides super fast native file system watching
-  // of server files. Either server.js/ts or any js/ts files inside a folder named server
-  const serverWatcher = chokidar.watch(
-    [
-      "build.js",
-      "build.ts",
-      "document.js",
-      "document.ts",
-      "server.js",
-      "server.ts",
-      "server/**/*.js",
-      "server/**/*.ts",
-      "config/**/*.json",
-      "config/schema.js",
-      "config/schema.ts",
-      "schemas/**/*.json",
-      "locale/**/*.json",
-      "locales/**/*.po",
-    ],
-    {
-      persistent: true,
-      followSymlinks: false,
-      cwd,
-    }
-  );
-  serverWatcher.on("error", async (err) => {
-    logger.error(err, "server watcher error: disposing of build context");
-    await buildContext.dispose();
-  });
-
-  let debounceTimer;
-  function serverFileChange(type) {
-    return async (name) => {
-      clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(async () => {
-        console.clear();
-        const greeting = chalk.white.bold(`Podium Podlet Server (v${version})`);
-        const msgBox = boxen(greeting, { padding: 0.5 });
-        console.log(msgBox);
-        logger.debug(`📁 ${chalk.blue(`file ${type}`)}: ${name}`);
-        try {
-          // extract in case translations were added
-          // @ts-ignore
-          await linguiExtract({ linguiConfig, cwd, hideStats: true });
-          // compile in case a .po file changed
-          // @ts-ignore
-          await linguiCompile({ linguiConfig, config });
-          // TODO: only reload the area related to the changed file
-          await state.get("local").reload();
-          await devServer.restart();
-        } catch (err) {
-          logger.error(err);
-          buildContext.dispose();
-        }
-        logger.debug(`${chalk.green("♻️")}  ${chalk.blue("server restarted")}`);
-      }, 250);
-    };
-  }
-
-  // restart the server whenever a server related file changes, is added or is deleted
-  serverWatcher.on("ready", () => {
-    // wait 1 second for the build/app start to settle
-    setTimeout(() => {
-      serverWatcher.on("change", serverFileChange("changed"));
-      serverWatcher.on("add", serverFileChange("added"));
-      serverWatcher.on("unlink", serverFileChange("deleted"));
-    }, 1000);
-  });
-
-  serverWatcher.on("error", (err) => {
-    logger.error(err, "Uh Oh! Something went wrong with server side file watching. Got error");
-  });
-
-  // start the server for the first time
-  try {
-    await devServer.start();
-  } catch (err) {
-    logger.error(err);
-    await serverWatcher.close();
-    buildContext.dispose();
-    process.exit(1);
-  }
-}
-

--- a/api/dev.js
+++ b/api/dev.js
@@ -119,7 +119,7 @@ export class DevServer {
       }
     );
     this.webSocketServer = new WebSocketServer({
-      port: 3925,
+      port: config.get("development.liveReload.port"),
     });
     /**
      * @typedef {import("ws").WebSocket & { isAlive: boolean }} WebSocketE

--- a/commands/dev.js
+++ b/commands/dev.js
@@ -4,7 +4,7 @@ import { Core } from "../lib/resolvers/core.js";
 import { Extensions } from "../lib/resolvers/extensions.js";
 import { State } from "../lib/state.js";
 
-import { dev } from "../api/dev.js";
+import { DevServer } from "../api/dev.js";
 
 export const command = "dev";
 
@@ -35,5 +35,6 @@ export const handler = async (argv) => {
 
   const config = await configuration({ cwd, schemas: await state.config() });
 
-  await dev({ state, config, cwd });
+  const devServer = new DevServer({ state, config, cwd });
+  await devServer.start();
 };

--- a/lib/config-schema.js
+++ b/lib/config-schema.js
@@ -147,6 +147,15 @@ export const schema = {
       default: false,
     },
   },
+  development: {
+    liveReload: {
+      port: {
+        doc: "The port to expose the live reload web socket service on",
+        format: "port",
+        default: null,
+      }
+    },
+  },
 };
 
 export const formats = {

--- a/lib/config.js
+++ b/lib/config.js
@@ -80,6 +80,11 @@ export default async function configuration({ schemas = [], cwd = process.cwd() 
     config.load({ app: { base: `/${config.get("app.name")}` } });
   }
 
+  // If development.liveReload.port is not explicitly user set, then default it to app.port + 1
+  if (!config.get("development.liveReload.port")) {
+    config.set("development.liveReload.port", config.get("app.port") + 1);
+  }
+
   // once all is setup, validate.
   config.validate();
 

--- a/lib/lingui-compile.js
+++ b/lib/lingui-compile.js
@@ -7,7 +7,6 @@ import chalk from "chalk";
 /**
  * Compile messages using the Lingui API.
  * @param {object} options - The options for the lingui compile method.
- * @param {string} options.cwd - The current working directory.
  * @param {import("@lingui/conf").LinguiConfig} options.linguiConfig - Lingui config object
  * @param {import("convict").Config} options.config - The podlet configuration.
  * @returns {Promise<void>}

--- a/lib/lingui-config.js
+++ b/lib/lingui-config.js
@@ -6,7 +6,7 @@ import PathResolver from "../lib/path.js";
  * @param {object} options
  * @param {string} options.cwd - The current working directory.
  * @param {import("convict").Config} options.config - The podlet configuration.
- * @returns
+ * @returns {Promise<import("@lingui/conf").LinguiConfig | undefined>}
  */
 export async function getLinguiConfig({ config, cwd }) {
   try {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -43,210 +43,221 @@ const defaults = {
  * @typedef {import("fastify").FastifyContextConfig & { timing: boolean }} FastifyContextConfig
  */
 
-export default fp(async function (fastify, { prefix = "/", extensions, cwd = process.cwd(), plugins = [], config }) {
-  const base = config.get("assets.base") || "/";
-  const name = config.get("app.name");
-  const port = config.get("app.port");
-  const pathname = config.get("podlet.pathname") || "/";
-  const manifest = config.get("podlet.manifest") || "/manifest.json";
-  const content = config.get("podlet.content") || "/";
-  const fallback = config.get("podlet.fallback") || "";
-  const development = config.get("app.development") || false;
-  const version = config.get("podlet.version") || null;
-  const locale = config.get("app.locale") || "";
-  const lazy = config.get("assets.lazy") || false;
-  const scripts = config.get("assets.scripts") || false;
-  const compression = config.get("app.compression");
-  const grace = config.get("app.grace") || 0;
-  const timeAllRoutes = config.get("metrics.timing.timeAllRoutes") || true;
-  const groupStatusCodes = config.get("metrics.timing.groupStatusCodes") || true;
-  const mode = config.get("app.mode") || "hydrate";
+export default fp(
+  /**
+   *
+   * @param {import("fastify").FastifyInstance} fastify
+   * @param {{ prefix: string, extensions: import("./resolvers/extensions.js").Extensions, cwd: string, plugins: import("esbuild").Plugin[], config: import("convict").Config, webSocketServer?: import("ws").WebSocketServer, clientWatcher?: import("chokidar").FSWatcher }} options
+   */
+  async function (
+    fastify,
+    { prefix = "/", extensions, cwd = process.cwd(), plugins = [], config, webSocketServer, clientWatcher }
+  ) {
+    // @ts-ignore
+    const base = config.get("assets.base") || "/";
+    const name = config.get("app.name");
+    const port = config.get("app.port");
+    const pathname = config.get("podlet.pathname") || "/";
+    const manifest = config.get("podlet.manifest") || "/manifest.json";
+    const content = config.get("podlet.content") || "/";
+    const fallback = config.get("podlet.fallback") || "";
+    const development = config.get("app.development") || false;
+    const version = config.get("podlet.version") || null;
+    const locale = config.get("app.locale") || "";
+    const lazy = config.get("assets.lazy") || false;
+    const scripts = config.get("assets.scripts") || false;
+    const compression = config.get("app.compression");
+    const grace = config.get("app.grace") || 0;
+    const timeAllRoutes = config.get("metrics.timing.timeAllRoutes") || true;
+    const groupStatusCodes = config.get("metrics.timing.groupStatusCodes") || true;
+    const mode = config.get("app.mode") || "hydrate";
 
-  const assetBase = isAbsoluteURL(base) ? base : joinURLPathSegments(prefix, base);
-  const contentFilePath = await resolve(join(cwd, "./content.js"));
-  const fallbackFilePath = await resolve(join(cwd, "./fallback.js"));
+    const assetBase = isAbsoluteURL(base) ? base : joinURLPathSegments(prefix, base);
+    const contentFilePath = await resolve(join(cwd, "./content.js"));
+    const fallbackFilePath = await resolve(join(cwd, "./fallback.js"));
 
-  let podlet;
-  let metrics;
-  let schemas;
-  /** @type {stateFunction} */
-  let contentStateFn = async (req, context) => ({});
-  /** @type {stateFunction} */
-  let fallbackStateFn = async (req, context) => ({});
+    let podlet;
+    let metrics;
+    let schemas;
+    /** @type {stateFunction} */
+    let contentStateFn = async (req, context) => ({});
+    /** @type {stateFunction} */
+    let fallbackStateFn = async (req, context) => ({});
 
-  // wrap in scoped plugin for prefixed routes to work
-  await fastify.register(
-    async (fastify) => {
-      // cast fastify to include decorated properties
-      const f = /** @type {FastifyInstance} */ (fastify);
+    // wrap in scoped plugin for prefixed routes to work
+    await fastify.register(
+      async (fastify) => {
+        // cast fastify to include decorated properties
+        const f = /** @type {FastifyInstance} */ (fastify);
 
-      // load plugins
-      await f.register(podletPn, {
-        name,
-        version,
-        pathname,
-        manifest,
-        content,
-        fallback,
-        development,
-      });
-      await f.register(lazyPn, { enabled: lazy, base, development, prefix });
-      await f.register(scriptsPn, { enabled: scripts, base, development, prefix });
-      await f.register(liveReloadPn, { development, port, cwd, prefix });
-      await f.register(compressionPn, { enabled: compression });
-      await f.register(errorsPn);
-      await f.register(assetsPn, { base, cwd });
-      await f.register(bundlerPn, { cwd });
-      await f.register(exceptionsPn, { grace, development });
-      await f.register(hydratePn, { appName: name, base: assetBase, development, prefix });
-      await f.register(csrPn, { appName: name, base: assetBase, development, prefix });
-      await f.register(ssrPn, { appName: name, base, prefix });
-      await f.register(importElementPn, { appName: name, development, plugins, cwd });
-      await f.register(localePn, { locale, cwd, development });
-      await f.register(metricsPn);
-      await f.register(scriptPn, { development });
-      await f.register(timingPn, {
-        timeAllRoutes,
-        groupStatusCodes,
-      });
-      await f.register(validationPn, { prefix, defaults, mappings: { "/": "content.json" }, cwd });
-      await f.register(documentPn, { podlet: f.podlet, cwd, development, extensions });
-      await f.register(docsPn, { podlet: f.podlet, config, extensions });
-
-      // routes
-      if (existsSync(contentFilePath)) {
-        const tag = unsafeStatic(`${name}-content`);
-        f.get(f.podlet.content(), async (request, reply) => {
-          try {
-            const contextConfig = /** @type {FastifyContextConfig} */ (reply.context.config);
-            contextConfig.timing = true;
-
-            if (mode === "ssr-only" || mode === "hydrate") {
-              // import server side component
-              await f.importElement(contentFilePath);
-            }
-
-            const initialState = JSON.stringify(
-              // @ts-ignore
-              (await contentStateFn(request, reply.app.podium.context)) || ""
-            );
-
-            const messages = await f.readTranslations();
-
-            const translations = messages ? JSON.stringify(messages) : "";
-
-            // includes ${null} hack for SSR. See https://github.com/lit/lit/issues/2246
-            const template = html`<${tag} version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${tag}>${null} `;
-            const hydrateSupport =
-              mode === "hydrate"
-                ? f.script(
-                    joinURLPathSegments(
-                      prefix,
-                      "/_/dynamic/modules/@lit-labs/ssr-client/lit-element-hydrate-support.js"
-                    ),
-                    { dev: development }
-                  )
-                : "";
-            const markup =
-              mode === "ssr-only"
-                ? f.ssr("content", template)
-                : mode === "csr-only"
-                ? f.csr(
-                    "content",
-                    `<${name}-content version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${name}-content>`
-                  )
-                : f.hydrate("content", template);
-
-            reply.type("text/html; charset=utf-8").send(`${hydrateSupport}${markup}`);
-
-            return reply;
-          } catch (err) {
-            f.log.error(err);
-          }
+        // load plugins
+        await f.register(podletPn, {
+          name,
+          version,
+          pathname,
+          manifest,
+          content,
+          fallback,
+          development,
         });
-      }
-
-      if (existsSync(fallbackFilePath)) {
-        const tag = unsafeStatic(`${name}-fallback`);
-        f.get(f.podlet.fallback(), async (request, reply) => {
-          try {
-            const contextConfig = /** @type {FastifyContextConfig} */ (reply.context.config);
-            contextConfig.timing = true;
-
-            if (mode === "ssr-only" || mode === "hydrate") {
-              // import server side component
-              await f.importElement(fallbackFilePath);
-            }
-
-            const initialState = JSON.stringify(
-              // @ts-ignore
-              (await fallbackStateFn(request, reply.app.podium.context)) || ""
-            );
-
-            const messages = await f.readTranslations();
-
-            const translations = messages ? JSON.stringify(messages) : "";
-            const template = html`<${tag} version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${tag}>${null} `;
-            const hydrateSupport =
-              mode === "hydrate"
-                ? f.script(
-                    joinURLPathSegments(
-                      prefix,
-                      "/_/dynamic/modules/@lit-labs/ssr-client/lit-element-hydrate-support.js"
-                    ),
-                    { dev: development }
-                  )
-                : "";
-            const markup =
-              mode === "ssr-only"
-                ? f.ssr("fallback", template)
-                : mode === "csr-only"
-                ? f.csr(
-                    "fallback",
-                    `<${name}-fallback version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${name}-fallback>`
-                  )
-                : f.hydrate("fallback", template);
-
-            reply.type("text/html; charset=utf-8").send(`${hydrateSupport}${markup}`);
-
-            return reply;
-          } catch (err) {
-            f.log.error(err);
-          }
+        await f.register(lazyPn, { enabled: lazy, base, development, prefix });
+        await f.register(scriptsPn, { enabled: scripts, base, development, prefix });
+        await f.register(liveReloadPn, { development, port, prefix, clientWatcher, webSocketServer });
+        await f.register(compressionPn, { enabled: compression });
+        await f.register(errorsPn);
+        await f.register(assetsPn, { base, cwd });
+        await f.register(bundlerPn, { cwd });
+        await f.register(exceptionsPn, { grace, development });
+        await f.register(hydratePn, { appName: name, base: assetBase, development, prefix });
+        await f.register(csrPn, { appName: name, base: assetBase, development, prefix });
+        await f.register(ssrPn, { appName: name, base, prefix });
+        await f.register(importElementPn, { appName: name, development, plugins, cwd });
+        await f.register(localePn, { locale, cwd, development });
+        await f.register(metricsPn);
+        await f.register(scriptPn, { development });
+        await f.register(timingPn, {
+          timeAllRoutes,
+          groupStatusCodes,
         });
-      }
+        await f.register(validationPn, { prefix, defaults, mappings: { "/": "content.json" }, cwd });
+        await f.register(documentPn, { podlet: f.podlet, cwd, development, extensions });
+        await f.register(docsPn, { podlet: f.podlet, config, extensions });
 
-      // expose decorators to outer plugin wrapper
+        // routes
+        if (existsSync(contentFilePath)) {
+          const tag = unsafeStatic(`${name}-content`);
+          f.get(f.podlet.content(), async (request, reply) => {
+            try {
+              const contextConfig = /** @type {FastifyContextConfig} */ (reply.context.config);
+              contextConfig.timing = true;
 
-      podlet = f.podlet;
-      metrics = f.metrics;
-      schemas = f.schemas;
-    },
-    { prefix }
-  );
+              if (mode === "ssr-only" || mode === "hydrate") {
+                // import server side component
+                await f.importElement(contentFilePath);
+              }
 
-  // Expose developer facing APIs using decorate
-  /**
-   * @typedef {(req: import('fastify').FastifyRequest, context: any) => Promise<{ [key: string]: any; [key: number]: any; } | null>} stateFunction
-   */
+              const initialState = JSON.stringify(
+                // @ts-ignore
+                (await contentStateFn(request, reply.app.podium.context)) || ""
+              );
 
-  /**
-   * @param {stateFunction} stateFunction
-   */
-  function setContentState(stateFunction) {
-    contentStateFn = stateFunction;
+              const messages = await f.readTranslations();
+
+              const translations = messages ? JSON.stringify(messages) : "";
+
+              // includes ${null} hack for SSR. See https://github.com/lit/lit/issues/2246
+              const template = html`<${tag} version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${tag}>${null} `;
+              const hydrateSupport =
+                mode === "hydrate"
+                  ? f.script(
+                      joinURLPathSegments(
+                        prefix,
+                        "/_/dynamic/modules/@lit-labs/ssr-client/lit-element-hydrate-support.js"
+                      ),
+                      { dev: development }
+                    )
+                  : "";
+              const markup =
+                mode === "ssr-only"
+                  ? f.ssr("content", template)
+                  : mode === "csr-only"
+                  ? f.csr(
+                      "content",
+                      `<${name}-content version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${name}-content>`
+                    )
+                  : f.hydrate("content", template);
+
+              reply.type("text/html; charset=utf-8").send(`${hydrateSupport}${markup}`);
+
+              return reply;
+            } catch (err) {
+              f.log.error(err);
+            }
+          });
+        }
+
+        if (existsSync(fallbackFilePath)) {
+          const tag = unsafeStatic(`${name}-fallback`);
+          f.get(f.podlet.fallback(), async (request, reply) => {
+            try {
+              const contextConfig = /** @type {FastifyContextConfig} */ (reply.context.config);
+              contextConfig.timing = true;
+
+              if (mode === "ssr-only" || mode === "hydrate") {
+                // import server side component
+                await f.importElement(fallbackFilePath);
+              }
+
+              const initialState = JSON.stringify(
+                // @ts-ignore
+                (await fallbackStateFn(request, reply.app.podium.context)) || ""
+              );
+
+              const messages = await f.readTranslations();
+
+              const translations = messages ? JSON.stringify(messages) : "";
+              const template = html`<${tag} version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${tag}>${null} `;
+              const hydrateSupport =
+                mode === "hydrate"
+                  ? f.script(
+                      joinURLPathSegments(
+                        prefix,
+                        "/_/dynamic/modules/@lit-labs/ssr-client/lit-element-hydrate-support.js"
+                      ),
+                      { dev: development }
+                    )
+                  : "";
+              const markup =
+                mode === "ssr-only"
+                  ? f.ssr("fallback", template)
+                  : mode === "csr-only"
+                  ? f.csr(
+                      "fallback",
+                      `<${name}-fallback version="${version}" locale='${locale}' translations='${translations}' initial-state='${initialState}'></${name}-fallback>`
+                    )
+                  : f.hydrate("fallback", template);
+
+              reply.type("text/html; charset=utf-8").send(`${hydrateSupport}${markup}`);
+
+              return reply;
+            } catch (err) {
+              f.log.error(err);
+            }
+          });
+        }
+
+        // expose decorators to outer plugin wrapper
+
+        podlet = f.podlet;
+        metrics = f.metrics;
+        schemas = f.schemas;
+      },
+      { prefix }
+    );
+
+    // Expose developer facing APIs using decorate
+    /**
+     * @typedef {(req: import('fastify').FastifyRequest, context: any) => Promise<{ [key: string]: any; [key: number]: any; } | null>} stateFunction
+     */
+
+    /**
+     * @param {stateFunction} stateFunction
+     */
+    function setContentState(stateFunction) {
+      contentStateFn = stateFunction;
+    }
+
+    /**
+     * @param {stateFunction} stateFunction
+     */
+    function setFallbackState(stateFunction) {
+      fallbackStateFn = stateFunction;
+    }
+
+    fastify.decorate("setContentState", setContentState);
+    fastify.decorate("setFallbackState", setFallbackState);
+    fastify.decorate("podlet", podlet);
+    fastify.decorate("metrics", metrics);
+    fastify.decorate("schemas", schemas);
   }
-
-  /**
-   * @param {stateFunction} stateFunction
-   */
-  function setFallbackState(stateFunction) {
-    fallbackStateFn = stateFunction;
-  }
-
-  fastify.decorate("setContentState", setContentState);
-  fastify.decorate("setFallbackState", setFallbackState);
-  fastify.decorate("podlet", podlet);
-  fastify.decorate("metrics", metrics);
-  fastify.decorate("schemas", schemas);
-});
+);

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -71,6 +71,7 @@ export default fp(
     const timeAllRoutes = config.get("metrics.timing.timeAllRoutes") || true;
     const groupStatusCodes = config.get("metrics.timing.groupStatusCodes") || true;
     const mode = config.get("app.mode") || "hydrate";
+    const webSocketServerPort = config.get("development.liveReload.port");
 
     const assetBase = isAbsoluteURL(base) ? base : joinURLPathSegments(prefix, base);
     const contentFilePath = await resolve(join(cwd, "./content.js"));
@@ -102,7 +103,14 @@ export default fp(
         });
         await f.register(lazyPn, { enabled: lazy, base, development, prefix });
         await f.register(scriptsPn, { enabled: scripts, base, development, prefix });
-        await f.register(liveReloadPn, { development, port, prefix, clientWatcher, webSocketServer });
+        await f.register(liveReloadPn, {
+          development,
+          port,
+          prefix,
+          clientWatcher,
+          webSocketServer,
+          webSocketServerPort,
+        });
         await f.register(compressionPn, { enabled: compression });
         await f.register(errorsPn);
         await f.register(assetsPn, { base, cwd });

--- a/plugins/live-reload.js
+++ b/plugins/live-reload.js
@@ -1,173 +1,76 @@
-// @ts-ignore
-import chokidar from "chokidar";
 import fp from "fastify-plugin";
 import etag from "@fastify/etag";
 import cors from "@fastify/cors";
-import { WebSocketServer } from "ws";
 import { joinURLPathSegments } from "../lib/utils.js";
 
-const watch = [
-  "content.js",
-  "content.ts",
-  "fallback.js",
-  "fallback.ts",
-  "scripts.js",
-  "scripts.ts",
-  "lazy.js",
-  "lazy.ts",
-  "client/**/*.js",
-  "client/**/*.ts",
-  "lib/**/*.js",
-  "lib/**/*.ts",
-  "src/**/*.js",
-  "src/**/*.ts",
-  "locales/**/*.po",
-];
-
-export default fp(
-  async (fastify, { cwd = process.cwd(), development, port, prefix = "/" }, next) => {
-    if (!development) return next();
-
-    const liveReloadServerPath = joinURLPathSegments(prefix, `/_/live/reload`);
-    const liveReloadClientPath = joinURLPathSegments(prefix, `/_/live/client`);
-
-    await fastify.register(etag, {
-      algorithm: "fnv1a",
-    });
-
-    await fastify.register(cors);
-
-    const wss = new WebSocketServer({
-      server: fastify.server,
-      path: liveReloadServerPath,
-    });
-
-    function onFileChange() {
-      wss.clients.forEach((client) => {
-        client.send("update", () => {
-          // Something went wrong....
-        });
-      });
-    }
-
-    /**
-     * @typedef {import("ws").WebSocket & { isAlive: boolean }} WebSocketE
-     */
-
-    wss.on(
-      "connection",
-      /** @param {WebSocketE} ws */
-      (ws) => {
-        fastify.log.debug("live reload - server got connection from browser");
-
-        ws.isAlive = true;
-
-        ws.on("pong", () => {
-          ws.isAlive = true;
-        });
-
-        ws.on("error", (error) => {
-          fastify.log.debug("live reload - connection to browser errored");
-          fastify.log.error(error);
-        });
+const CLIENT = `(() => {
+  const livereload = () => {
+    const ws = new WebSocket('ws://localhost:3925');
+    ws.addEventListener("message", (event) => {
+      if (event.data === 'update') {
+        window.location.reload(true);
       }
-    );
-
-    const pingpong = setInterval(() => {
-      wss.clients.forEach(
-        (client) => {
-          // Typescript casting dance to add the isAlive property to WebSocket
-        const c = /** @type {WebSocketE} */ (client);
-        if (c.isAlive === false) return c.terminate();
-        c.isAlive = false;
-        c.ping(() => {
-          // noop
-        });
-      });
-    }, 30000);
-
-    wss.on("error", (error) => {
-      fastify.log.debug("live reload - server errored");
-      fastify.log.error(error);
     });
-
-    wss.on("close", () => {
-      fastify.log.debug("live reload - server closed");
-      clearInterval(pingpong);
+    ws.addEventListener("close", () => {
+      setTimeout(() => {
+        livereload();
+      }, 1000);
     });
-
-    const watcher = chokidar.watch(watch, {
-      persistent: true,
-      followSymlinks: false,
-      cwd,
+    ws.addEventListener("error", () => {
+      ws.close();
     });
+  };
+  livereload();
+})()`;
 
-    watcher.on("ready", () => {
-      watcher.on("change", onFileChange);
-      watcher.on("add", onFileChange);
-      watcher.on("unlink", onFileChange);
-    });
+export default fp(async (fastify, { development, port, prefix = "/", clientWatcher, webSocketServer }) => {
+  if (!development) return;
 
-    watcher.on("error", (error) => {
-      fastify.log.debug("live reload - file watching errored");
-      fastify.log.error(error);
-    });
+  const liveReloadClientPath = joinURLPathSegments(prefix, `/_/live/client`);
 
-    async function cleanup() {
-      await watcher.close();
-      await new Promise((resolve) => wss.close(resolve));
-    }
-
-    fastify.addHook("onClose", cleanup);
-
-    fastify.get("/_/live/client", (request, reply) => {
-      reply.type("application/javascript");
-      reply.send(`(() => {
-const livereload = () => {
-  const ws = new WebSocket('ws://localhost:${port}${liveReloadServerPath}');
-  ws.addEventListener("message", (event) => {
-    if (event.data === 'update') {
-      window.location.reload(true);
-    }
+  await fastify.register(etag, {
+    algorithm: "fnv1a",
   });
-  ws.addEventListener("close", () => {
-    setTimeout(() => {
-      livereload();
-    }, 1000);
-  });
-  ws.addEventListener("error", () => {
-    ws.close();
-  });
-};
-livereload();
-})()`);
-    });
 
-    fastify.addHook("onSend", (request, reply, /** @type {string} */ payload, done) => {
-      let newPayload = payload;
-      const contentType = reply.getHeader("content-type") || "";
-      if (typeof contentType === "string") {
-        // only inject live reload if the content type is html
-        if (contentType.includes("html")) {
-          // if there is a document, inject before closing body
-          // @ts-ignore
-          if (payload.includes("</body>")) {
-            newPayload = payload.replace(
-              "</body>",
-              `<script src="http://localhost:${port}${liveReloadClientPath}" type="module"></script></body>`
-            );
-          } else {
-            // if no document, inject at the end of the payload
-            newPayload = `${payload}<script src="http://localhost:${port}${liveReloadClientPath}" type="module"></script>`;
-          }
+  // in case podlet is being used with a layout
+  await fastify.register(cors);
+
+  function onFileChange() {
+    webSocketServer.clients.forEach((client) => {
+      client.send("update");
+    });
+  }
+
+  if (clientWatcher) {
+    clientWatcher.on("change", onFileChange);
+    clientWatcher.on("add", onFileChange);
+    clientWatcher.on("unlink", onFileChange);
+  }
+
+  fastify.get("/_/live/client", (request, reply) => {
+    reply.type("application/javascript");
+    reply.send(CLIENT);
+  });
+
+  fastify.addHook("onSend", (request, reply, /** @type {string} */ payload, done) => {
+    let newPayload = payload;
+    const contentType = reply.getHeader("content-type") || "";
+    if (typeof contentType === "string") {
+      // only inject live reload if the content type is html
+      if (contentType.includes("html")) {
+        // if there is a document, inject before closing body
+        // @ts-ignore
+        if (payload.includes("</body>")) {
+          newPayload = payload.replace(
+            "</body>",
+            `<script src="http://localhost:${port}${liveReloadClientPath}" type="module"></script></body>`
+          );
+        } else {
+          // if no document, inject at the end of the payload
+          newPayload = `${payload}<script src="http://localhost:${port}${liveReloadClientPath}" type="module"></script>`;
         }
       }
-      done(null, newPayload);
-    });
-
-    next();
-  },
-  {
-    name: "plugin-live-reload",
-  }
-);
+    }
+    done(null, newPayload);
+  });
+});

--- a/plugins/live-reload.js
+++ b/plugins/live-reload.js
@@ -47,6 +47,16 @@ export default fp(async (fastify, { development, port, prefix = "/", clientWatch
     clientWatcher.on("unlink", onFileChange);
   }
 
+  // ensure we dont get 503s when using live reload
+  fastify.addHook("onSend", (req, reply, payload, done) => {
+    reply.header("connection", "close");
+    done();
+  })
+
+  fastify.addHook("onReady", () => {
+    onFileChange();
+  });
+
   fastify.get("/_/live/client", (request, reply) => {
     reply.type("application/javascript");
     reply.send(CLIENT);

--- a/plugins/live-reload.js
+++ b/plugins/live-reload.js
@@ -45,6 +45,10 @@ export default fp(async (fastify, { development, port, prefix = "/", clientWatch
     clientWatcher.on("change", onFileChange);
     clientWatcher.on("add", onFileChange);
     clientWatcher.on("unlink", onFileChange);
+
+    fastify.addHook("onReady", () => {
+      onFileChange();
+    });
   }
 
   // ensure we dont get 503s when using live reload
@@ -52,10 +56,6 @@ export default fp(async (fastify, { development, port, prefix = "/", clientWatch
     reply.header("connection", "close");
     done();
   })
-
-  fastify.addHook("onReady", () => {
-    onFileChange();
-  });
 
   fastify.get("/_/live/client", (request, reply) => {
     reply.type("application/javascript");

--- a/test/lib/plugin.test.js
+++ b/test/lib/plugin.test.js
@@ -55,6 +55,7 @@ async function setupConfig() {
   config.set("metrics.timing.timeAllRoutes", false);
   config.set("metrics.timing.groupStatusCodes", false);
   config.set("app.mode", "hydrate");
+  config.set("development.liveReload.port", 8081);
   return config;
 }
 

--- a/test/plugins/plugins-live-reload.test.js
+++ b/test/plugins/plugins-live-reload.test.js
@@ -18,7 +18,7 @@ test("live reload script not injected when not in development mode", async (t) =
 
 test("live reload script injected when content-type is html and app in development mode, no prefix", async (t) => {
   const app = fastify({ logger: false });
-  await app.register(plugin, { development: true, port: 1234 });
+  await app.register(plugin, { development: true, port: 1234, webSocketServerPort: 1235 });
   app.get("/", (request, reply) => {
     reply.type("text/html");
     reply.send("<div>hello world</div>");
@@ -37,7 +37,7 @@ test("live reload script injected when content-type is html and app in developme
   const response2 = await result2.text();
   t.match(
     response2,
-    `const ws = new WebSocket('ws://localhost:3925');`,
+    `const ws = new WebSocket(\`ws://\${host}:1235\`);`,
     "should inject correct live reload script URL"
   );
   await app.close();
@@ -47,7 +47,7 @@ test("live reload script injected in wrapping plugin with prefix /foo", async (t
   const app = fastify({ logger: false });
   await app.register(
     async (f) => {
-      await f.register(plugin, { development: true, port: 1235, prefix: "/foo" });
+      await f.register(plugin, { development: true, port: 1235, prefix: "/foo", webSocketServerPort: 1236 });
       f.get("/", (request, reply) => {
         reply.type("text/html");
         reply.send("<div>hello world</div>");
@@ -69,7 +69,7 @@ test("live reload script injected in wrapping plugin with prefix /foo", async (t
   const response2 = await result2.text();
   t.match(
     response2,
-    `const ws = new WebSocket('ws://localhost:3925');`,
+    `const ws = new WebSocket(\`ws://\${host}:1236\`);`,
     "should inject correct live reload script URL"
   );
   await app.close();

--- a/test/plugins/plugins-live-reload.test.js
+++ b/test/plugins/plugins-live-reload.test.js
@@ -37,7 +37,7 @@ test("live reload script injected when content-type is html and app in developme
   const response2 = await result2.text();
   t.match(
     response2,
-    `const ws = new WebSocket('ws://localhost:1234/_/live/reload');`,
+    `const ws = new WebSocket('ws://localhost:3925');`,
     "should inject correct live reload script URL"
   );
   await app.close();
@@ -69,7 +69,7 @@ test("live reload script injected in wrapping plugin with prefix /foo", async (t
   const response2 = await result2.text();
   t.match(
     response2,
-    `const ws = new WebSocket('ws://localhost:1235/foo/_/live/reload');`,
+    `const ws = new WebSocket('ws://localhost:3925');`,
     "should inject correct live reload script URL"
   );
   await app.close();


### PR DESCRIPTION
This PR moves file watching and the web socket server out of fastify plugins.

The motivation for this is threefold:
1. Perf: when the ws and file watching are inside a plugin, they must be shut down and re setup on every server restart
2. Ease: I've found it a challenge to try to cleanly shut down the web socket in particular on each server restart. Intermittent server hangs have been hard to avoid. With this PR, this stops being a challenge.
3. Reuse: Managing the file watcher and ws at the top level and passing it down to plugins means that other plugins can also make use of the file watcher and respond when files change.

Thoughts @trygve-lie?