### PR TITLE
fix: prevent undefined registry error and further reduce intermittent page reload delay error

### DIFF
--- a/lib/pino-dev-transport.js
+++ b/lib/pino-dev-transport.js
@@ -75,6 +75,9 @@ export default (options) =>
       } else if (log.url && msg.includes("Development server listening")) {
         // handle custom server listening message
         message = `🖥️  ${msg} on ${chalk.magenta(log.url)}`;
+      } else if (log.url && msg.includes("Development server restarted")) {
+        // handle custom server restarted message
+        message = `💫 ${msg} on ${chalk.magenta(log.url)}`;
       } else if (msg.includes("Server listening at http")) {
         // swallow default server listening message
         return "";
@@ -97,7 +100,7 @@ export default (options) =>
       }
       // warn
       else if (level === 40) {
-        return `${chalk.yellow(message)}\n`;
+        return `😬 ${chalk.yellow(message)}\n`;
       }
       // info
       else if (level === 30) {

--- a/plugins/import-element.js
+++ b/plugins/import-element.js
@@ -17,6 +17,7 @@ class CustomElementRegistry {
     this.development = development;
   }
   define(name, ctor) {
+    if (!name || !ctor) return;
     // we turn off this check for development mode to allow us to replace existing definitions each time
     // a file changes on disk.
     if (!this.development && this.__definitions.has(name)) {

--- a/plugins/live-reload.js
+++ b/plugins/live-reload.js
@@ -9,15 +9,21 @@ const clideSideScript = (port) => `(() => {
     const ws = new WebSocket(\`ws://\${host}:${port}\`);
     ws.addEventListener("message", (event) => {
       if (event.data === 'update') {
-        window.location.reload(true);
+        console.debug("live reload update, reloading page");
+        // short timeout seems to avoid intermittent page reload failures
+        setTimeout(() => {
+          window.location.reload(true);
+        }, 50);
       }
     });
     ws.addEventListener("close", () => {
+      console.debug("live reload socket closed, reconnecting in 1s");
       setTimeout(() => {
         livereload();
       }, 1000);
     });
     ws.addEventListener("error", () => {
+      console.debug("live reload error detected, closing socket");
       ws.close();
     });
   };


### PR DESCRIPTION
Introducing a slight delay to reload seems to dramatically reduce the number of intermittent errors (with this PR in my testing I only managed to make the error occur 1x) when live reloading the page. The error seems to relate to a failed request to the server after the server is restarted.

Changes to config files no longer reloads the server. Instead, the user is informed that they need to manually restart the server due to a configuration change. Config files can't easily be reloaded as part of the change and reload cycle so its best to just inform the user and let them reload.

Fixes rare bug on reload where the custom element registry gets an undefined value. 