### PR TITLE
Making TestServer comply with the log level set in the configuration

### DIFF
--- a/test/api/memory-destination.js
+++ b/test/api/memory-destination.js
@@ -1,0 +1,16 @@
+const MemoryDestination = {
+
+  logs: [],
+
+  // called by pino
+  write(chunk) {
+    this.logs.push(chunk)
+  },
+
+  reset() {
+    const current = this.logs
+    this.logs = []
+    return current
+  }
+}
+export default MemoryDestination

--- a/test/api/server.test.js
+++ b/test/api/server.test.js
@@ -1,0 +1,45 @@
+import fs from "node:fs"
+import pino from "pino"
+import tap from "tap"
+
+import memoryDestination from "./memory-destination.js"
+import { TestServer } from "../../api/index.js"
+
+const logLevelDebug = "debug"
+
+tap.before(() => {
+  // Hack to work around the Podlet using the package.json name on creation
+  fs.writeFileSync("package.json", `{"name": "test", "type": "module"}`)
+})
+
+tap.teardown(() => {
+  fs.unlinkSync("package.json")
+
+})
+tap.afterEach(async () => {
+  memoryDestination.reset()
+})
+tap.test("Logs with debug level when told to", async (t) => {
+  const server = await TestServer.create({
+    cwd: process.cwd(), development: true,
+    loggerFunction: () => pino({ level: logLevelDebug }, memoryDestination)
+  })
+  server.config.set("app.logLevelDebug", logLevelDebug)
+  await server.start()
+  t.equal(memoryDestination.logs.length, 3)
+  await server.stop()
+  t.end();
+})
+
+tap.test("Logs nothing when set to error", async (t) => {
+  const logLevelSilent = "silent"
+  const server = await TestServer.create({
+    cwd: process.cwd(), development: true,
+    loggerFunction: () => pino({ level: logLevelSilent }, memoryDestination)
+  })
+  server.config.set("app.logLevel", logLevelSilent)
+  await server.start()
+  t.equal(memoryDestination.logs.length, 0)
+  await server.stop()
+  t.end();
+})

--- a/test/api/server.test.js
+++ b/test/api/server.test.js
@@ -1,27 +1,27 @@
-import fs from "node:fs"
 import pino from "pino"
 import tap from "tap"
+import fs from "fs"
+import * as os from "os"
 
 import memoryDestination from "./memory-destination.js"
 import { TestServer } from "../../api/index.js"
 
 const logLevelDebug = "debug"
-
-tap.before(() => {
+const tempDirectory = os.tmpdir()
+tap.before(async () => {
   // Hack to work around the Podlet using the package.json name on creation
-  fs.writeFileSync("package.json", `{"name": "test", "type": "module"}`)
+  fs.writeFileSync(tempDirectory + "/package.json", `{"name": "test-server-app", "type": "module"}`)
 })
 
-tap.teardown(() => {
-  fs.unlinkSync("package.json")
-
+tap.teardown(async () => {
+  fs.unlinkSync(tempDirectory + "/package.json")
 })
 tap.afterEach(async () => {
   memoryDestination.reset()
 })
 tap.test("Logs with debug level when told to", async (t) => {
   const server = await TestServer.create({
-    cwd: process.cwd(), development: true,
+    cwd: tempDirectory, development: true,
     loggerFunction: () => pino({ level: logLevelDebug }, memoryDestination)
   })
   server.config.set("app.logLevelDebug", logLevelDebug)
@@ -34,7 +34,7 @@ tap.test("Logs with debug level when told to", async (t) => {
 tap.test("Logs nothing when set to error", async (t) => {
   const logLevelSilent = "silent"
   const server = await TestServer.create({
-    cwd: process.cwd(), development: true,
+    cwd: tempDirectory, development: true,
     loggerFunction: () => pino({ level: logLevelSilent }, memoryDestination)
   })
   server.config.set("app.logLevel", logLevelSilent)


### PR DESCRIPTION
This PR adds makes the `TestServer` use the configuration setting `app.logLevel` enabling you to choose the log level for your instance.

A side effect of testing this new behaviour is that the `create` method takes in a new property, `loggerFunction`. Enabling the tests added in `test/api/server.test.js` to verify that we actually do change the log levels.
Not super happy about the use of the `state` in here, so please come with suggestions 🙏 