### PR TITLE
Enabling build plugins to get passed config

### DIFF
--- a/GUIDE_EXTENSIONS.md
+++ b/GUIDE_EXTENSIONS.md
@@ -1,7 +1,9 @@
 Advanced Guide: Writing Extensions for Podium Podlet-Server
 ===========================================================
 
-This guide assumes you have already completed the beginner's guide and are familiar with the basics of setting up and running a Podium podlet server. In this advanced guide, we will cover how to create, publish, and use extensions for Podium podlet-server applications.
+This guide assumes you have already completed the beginner's guide and are familiar with the basics of setting up and
+running a Podium podlet server. In this advanced guide, we will cover how to create, publish, and use extensions for
+Podium podlet-server applications.
 
 Step 1: Create an extension project
 -----------------------------------
@@ -35,7 +37,8 @@ json
 Step 3: Implement the extension
 -------------------------------
 
-Create an `index.js` file in the project root and implement one or more of the optional hooks: `server`, `build`, `document`, and `config`.
+Create an `index.js` file in the project root and implement one or more of the optional
+hooks: `server`, `build`, `document`, and `config`.
 
 sh
 
@@ -58,9 +61,9 @@ export const server = async (app, opts) => {
 };
 
 // Build hook (esbuild plugins)
-export const build = async ({ cwd, development }) => [
-  // Add esbuild plugins here
-];
+export const build = async ({ cwd, development }) => [{
+  // Add one or more esbuild plugins
+}];
 
 // Document hook (Podium document template)
 export const document = (incoming, template) => {
@@ -77,7 +80,8 @@ export const config = ({ cwd, development }) => {
 Step 4: Publish the extension to npm
 ------------------------------------
 
-Before publishing your extension to npm, make sure you have an npm account and are logged in. If you don't have an account, create one at [npmjs.com](https://www.npmjs.com/).
+Before publishing your extension to npm, make sure you have an npm account and are logged in. If you don't have an
+account, create one at [npmjs.com](https://www.npmjs.com/).
 
 sh
 
@@ -105,17 +109,23 @@ json
 {
   "podium": {
     "extensions": {
-      "podlet-server": ["my-extension"]
+      "podlet-server": [
+        "my-extension"
+      ]
     }
   }
 }
 ```
 
-That's it! You have now successfully created, published, and used an extension for Podium podlet-server applications. This extension can enhance your Podium podlet-server applications with additional functionality, such as custom Fastify routes, esbuild plugins, Podium document templates, or Convict schema configuration.
+That's it! You have now successfully created, published, and used an extension for Podium podlet-server applications.
+This extension can enhance your Podium podlet-server applications with additional functionality, such as custom Fastify
+routes, esbuild plugins, Podium document templates, or Convict schema configuration.
 
 For more information on each of the hooks, refer to the following resources:
 
-*   Fastify plugins: [https://www.fastify.io/docs/latest/Guides/Plugins-Guide/](https://www.fastify.io/docs/latest/Guides/Plugins-Guide/)
-*   esbuild plugins: [https://esbuild.github.io/plugins/](https://esbuild.github.io/plugins/)
-*   Podium document templates: [https://podium-lib.io/docs/api/document](https://podium-lib.io/docs/api/document)
-*   Convict schema: \[[https://github.com/mozilla/node-convict/tree/master/packages/convict\](](https://github.com/mozilla/node-convict/tree/master/packages/convict%5D()[https://github.com/mozilla/node-convict](https://github.com/mozilla/node-convict)
+* Fastify
+  plugins: [https://www.fastify.io/docs/latest/Guides/Plugins-Guide/](https://www.fastify.io/docs/latest/Guides/Plugins-Guide/)
+* esbuild plugins: [https://esbuild.github.io/plugins/](https://esbuild.github.io/plugins/)
+* Podium document templates: [https://podium-lib.io/docs/api/document](https://podium-lib.io/docs/api/document)
+* Convict
+  schema: \[[https://github.com/mozilla/node-convict/tree/master/packages/convict\](](https://github.com/mozilla/node-convict/tree/master/packages/convict%5D()[https://github.com/mozilla/node-convict](https://github.com/mozilla/node-convict)

--- a/api/build.js
+++ b/api/build.js
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join, isAbsolute } from "node:path";
+import { isAbsolute, join } from "node:path";
 import esbuild from "esbuild";
 import resolve from "../lib/resolve.js";
 import rollupPluginTerser from "@rollup/plugin-terser";
@@ -98,7 +98,7 @@ export async function build({ state, config, cwd = process.cwd() }) {
       entryPoints.push(LAZY_ENTRY);
     }
 
-    const plugins = await state.build();
+    const plugins = await state.build(config);
 
     // build server side files
     try {
@@ -116,7 +116,8 @@ export async function build({ state, config, cwd = process.cwd() }) {
         sourcemap: false,
         external: ["lit"],
       });
-    } catch (err) {}
+    } catch (err) {
+    }
 
     // build dsd ponyfill
     await esbuild.build({

--- a/api/dev.js
+++ b/api/dev.js
@@ -193,7 +193,8 @@ export class DevServer {
       await mkdir("dist")
     })
 
-    const plugins = await this.state.build();
+    const plugins = await this.state.build(this.config);
+
     const extensions = this.state.get("extensions");
     for (const serverPlugin of await this.state.server()) {
       await app.register(serverPlugin, {

--- a/api/test.js
+++ b/api/test.js
@@ -81,7 +81,7 @@ export class TestServer {
       target: ["es2017"],
       legalComments: `none`,
       sourcemap: true,
-      plugins: await state.build(),
+      plugins: await state.build(this.config),
     });
   }
 

--- a/lib/state.js
+++ b/lib/state.js
@@ -106,7 +106,11 @@ export class State extends Map {
       }
     }
     if (this.has("local") && typeof this.get("local").build === "function") {
-      buildPlugins.push(...(await this.get("local").build({ cwd: this.cwd, development: this.development, config })));
+      let plugins = await this.get("local").build({ cwd: this.cwd, development: this.development, config });
+      if (!Array.isArray(plugins)) {
+        plugins = [plugins];
+      }
+      buildPlugins.push(...plugins);
     }
     return buildPlugins;
   }

--- a/lib/state.js
+++ b/lib/state.js
@@ -94,7 +94,15 @@ export class State extends Map {
     const buildPlugins = [];
     if (this.has("extensions")) {
       for (const buildFunction of this.get("extensions").build) {
-        buildPlugins.push(...(await buildFunction({ cwd: this.cwd, development: this.development, config })))
+        let plugins = await buildFunction({
+          cwd: this.cwd,
+          development: this.development,
+          config,
+        });
+        if (!Array.isArray(plugins)) {
+          plugins = [plugins];
+        }
+        buildPlugins.push(...plugins);
       }
     }
     if (this.has("local") && typeof this.get("local").build === "function") {

--- a/lib/state.js
+++ b/lib/state.js
@@ -90,15 +90,15 @@ export class State extends Map {
     return schemas;
   }
 
-  async build() {
+  async build(config) {
     const buildPlugins = [];
     if (this.has("extensions")) {
-      for (const buildPlugin of this.get("extensions").build) {
-        buildPlugins.push(...(await buildPlugin({ cwd: this.cwd, development: this.development })));
+      for (const buildFunction of this.get("extensions").build) {
+        buildPlugins.push(...(await buildFunction({ cwd: this.cwd, development: this.development, config })))
       }
     }
     if (this.has("local") && typeof this.get("local").build === "function") {
-      buildPlugins.push(...(await this.get("local").build({ cwd: this.cwd, development: this.development })));
+      buildPlugins.push(...(await this.get("local").build({ cwd: this.cwd, development: this.development, config })));
     }
     return buildPlugins;
   }

--- a/test/api/build.test.js
+++ b/test/api/build.test.js
@@ -1,8 +1,9 @@
-import { existsSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { mkdir, rm, writeFile } from "node:fs/promises";
-import { test, beforeEach, afterEach } from "tap";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { afterEach, beforeEach, test } from "tap";
+import * as os from "os";
+import { existsSync } from "node:fs";
+
 import configuration from "../../lib/config.js";
 import { build } from "../../api/build.js";
 import { Extensions } from "../../lib/resolvers/extensions.js";
@@ -10,7 +11,8 @@ import { Local } from "../../lib/resolvers/local.js";
 import { Core } from "../../lib/resolvers/core.js";
 import { State } from "../../lib/state.js";
 
-const tmp = join(tmpdir(), "./build-test-js");
+const tmpDir = join(os.tmpdir(), "build-test");
+const tmp = join(tmpDir, "./build-test-js");
 
 async function setupConfig({ cwd }) {
   const state = new State({ cwd });
@@ -31,7 +33,7 @@ beforeEach(async (t) => {
 });
 
 afterEach(async (t) => {
-  await rm(tmp, { recursive: true, force: true });
+  await rm(tmpDir, { recursive: true, force: true });
 });
 
 test("All possible supported JavaScript files defined and built", async (t) => {
@@ -45,7 +47,7 @@ test("All possible supported JavaScript files defined and built", async (t) => {
   // @ts-ignore
   config.set("app.name", "test-app");
   await build({ state, config, cwd: tmp });
-  
+
   // server versions built into server directory
   t.ok(existsSync(join(tmp, "dist", "server", "content.js")));
   t.ok(existsSync(join(tmp, "dist", "server", "fallback.js")));
@@ -77,7 +79,7 @@ test("All possible supported Typescript files defined and built", async (t) => {
   // @ts-ignore
   config.set("app.name", "test-app");
   await build({ state, config, cwd: tmp });
-  
+
   // server versions built into server directory
   t.ok(existsSync(join(tmp, "dist", "server", "content.js")));
   t.ok(existsSync(join(tmp, "dist", "server", "fallback.js")));
@@ -97,3 +99,40 @@ test("All possible supported Typescript files defined and built", async (t) => {
   t.ok(existsSync(join(tmp, "dist", "client", "scripts.js")));
   t.ok(existsSync(join(tmp, "dist", "client", "lazy.js")));
 });
+
+test("Build plugins receive the configuration object", async (t) => {
+  await writeFile(join(tmpDir, "package.json"), JSON.stringify({
+    name: "fake-app",
+    type: "module",
+    podium: {
+      extensions: { "podlet-server": ["fake-extension"] }
+    }
+  }));
+  await mkdir(join(tmpDir, "node_modules"));
+  await mkdir(join(tmpDir, "node_modules", "fake-extension"));
+  await writeFile(join(tmpDir, "node_modules", "fake-extension", "package.json"), JSON.stringify({
+    name: "fake-extension", version: "1.0.0", type: "module", main: "index.js"
+  }));
+
+  // A build plugin which writes the passed in config to a file for verification
+  const debugConfigFile = join(tmpDir, "config.txt");
+  await writeFile(join(tmpDir, "node_modules", "fake-extension", "index.js"), `
+    import fs from "fs"
+    
+    export const build = (config) => [{
+      name: "fake-build-plugin",
+      setup(build) {
+        fs.writeFileSync("${debugConfigFile}", JSON.stringify(config))
+      }
+    }]
+  `);
+
+  const { state, config } = await setupConfig({ cwd: tmpDir });
+  config.set("app.base", "/test-app");
+  config.set("app.name", "test-app");
+  await build({ state, config, cwd: tmp });
+
+  const file = (await readFile(debugConfigFile)).toString("utf-8");
+  t.equal(await config.load(JSON.parse(file).config), config, "Verified valid config is accessible");
+  await rm(debugConfigFile);
+})


### PR DESCRIPTION
This PR makes available the entire `config` object inside build plugins for authors to use. This is done in a non-breaking manner by adding an optional configuration parameter on the `build` method configuration object in the `State` class.

With this feature you can now write your build plugins using the configuration from the server 👇 👇 
```
export const build = (config) => [{
  name: "my-sweet-build-plugin",
  setup(build) {
      // here is how you use it inside your build plugin
     config.get("some.property.for.build")
  }
}]
```
Where the `config` argument is a Convict configuration object from the server(s). This feature is available in the dev, test and production versions of the server.