### PR TITLE
fix: config override files are on config/host/<hostname>/<env>.json

### DIFF
--- a/GUIDE_CONFIG.md
+++ b/GUIDE_CONFIG.md
@@ -1,26 +1,38 @@
 # Advanced Guide: Configuring a Podium Podlet Server
 
-This advanced guide will walk you through configuring your Podium podlet server using the config system. This guide assumes you have completed the beginner's guide and are familiar with the basics of creating a Podium podlet server.
+This advanced guide will walk you through configuring your Podium podlet server using the config system. This guide
+assumes you have completed the beginner's guide and are familiar with the basics of creating a Podium podlet server.
 
 ## A note on environment variables
 
 ### HOST and ENV
 
-Podlet server makes use of 2 core environment variables. HOST and ENV. Configuration in particular hangs off these values.
+Podlet server makes use of 2 core environment variables. HOST and ENV. Configuration in particular hangs off these
+values.
 
 #### HOST
 
-This is the host where the app is currently running. It's relatively freeform and podlet-server only really expects it to be a string. If HOST is not set, it will automatically be set to the value "localhost".
-We recommend you set this to different values for your staging and production environments. For example "staging.mysite.com" and "www.mysite.com" make good values. Whatever you set these to will affect what names you will need to give your configuration files. See below.
+This is the host where the app is currently running. It's relatively freeform and podlet-server only really expects it
+to be a string. If HOST is not set, it will automatically be set to the value "localhost".
+We recommend you set this to different values for your staging and production environments. For example "
+staging.mysite.com" and "www.mysite.com" make good values. Whatever you set these to will affect what names you will
+need to give your configuration files. See below.
 
 #### ENV
 
-This is the environment mode for the podlet server. If this value is not set, it will default to "local" and whenever the app ENV is local, development features such as file watching and reloading will be enabled.
-Podlet server won't enable development features if ENV is set to any other value than "local" and you can feel free to set this value to whatever best suits your setup. At Finn.no we use the values "local" for local development, "dev" for our staging environment and "prod" for our production environment but you could just use "local" and "production" if that suited you better. Whatever you choose will affect how you will need to name your configuration files. See below.
+This is the environment mode for the podlet server. If this value is not set, it will default to "local" and whenever
+the app ENV is local, development features such as file watching and reloading will be enabled.
+Podlet server won't enable development features if ENV is set to any other value than "local" and you can feel free to
+set this value to whatever best suits your setup. At Finn.no we use the values "local" for local development, "dev" for
+our staging environment and "prod" for our production environment but you could just use "local" and "production" if
+that suited you better. Whatever you choose will affect how you will need to name your configuration files. See below.
 
 ### Why we use ENV and not NODE_ENV
 
-NODE_ENV is an environment popularised by the Express js framework and as such it comes with typical expectations by many developers and libraries about how it should behave. The general convention is that it be set to either development or production. Configuration in a podlet-server on the other hand is centered around a more granular environment setup usually. local, staging and production or some variation upon this.
+NODE_ENV is an environment popularised by the Express js framework and as such it comes with typical expectations by
+many developers and libraries about how it should behave. The general convention is that it be set to either development
+or production. Configuration in a podlet-server on the other hand is centered around a more granular environment setup
+usually. local, staging and production or some variation upon this.
 
 ## Step 1: Create a config directory
 
@@ -38,7 +50,8 @@ Create a new file called common.json inside the config folder:
 touch config/common.json
 ```
 
-Open common.json in your text editor and add global configuration overrides. For example, if you want to change the app name:
+Open common.json in your text editor and add global configuration overrides. For example, if you want to change the app
+name:
 
 ```json
 {
@@ -72,28 +85,31 @@ mkdir config/hosts/www.example.com
 config files names must correspond to values you plan to use for your ENV variable:
 
 ```
-config/hosts/<HOST>/config.<ENV>.json
+config/hosts/<HOST>/<ENV>.json
 ```
 
-Inside each host folder, create environment-specific configuration files. For example, for a localhost host with local, staging, and production environments:
+Inside each host folder, create environment-specific configuration files. For example, for a localhost host with local,
+staging, and production environments:
 
 ```bash
-touch config/hosts/localhost/config.local.json
-touch config/hosts/localhost/config.staging.json
-touch config/hosts/localhost/config.production.json
+touch config/hosts/localhost/local.json
+touch config/hosts/localhost/staging.json
+touch config/hosts/localhost/production.json
 ```
 
 And for the www.example.com host:
 
 ```
-touch config/hosts/www.example.com/config.local.json
-touch config/hosts/www.example.com/config.staging.json
-touch config/hosts/www.example.com/config.production.json
+touch config/hosts/www.example.com/local.json
+touch config/hosts/www.example.com/staging.json
+touch config/hosts/www.example.com/production.json
 ```
-In each config file, override configuration values for the specific host and environment. For example, you can change the app.port for the local environment of the localhost host:
+
+In each config file, override configuration values for the specific host and environment. For example, you can change
+the app.port for the local environment of the localhost host:
 
 ```json5
-// config/hosts/localhost/config.local.json
+// config/hosts/localhost/local.json
 {
   "app": {
     "port": 8081
@@ -103,7 +119,8 @@ In each config file, override configuration values for the specific host and env
 
 ## Step 4 Create a schema file for custom configuration values
 
-If you need to extend the built-in config values with your own custom values, create a new file called schema.js inside the config folder:
+If you need to extend the built-in config values with your own custom values, create a new file called schema.js inside
+the config folder:
 
 ```bash
 touch config/schema.js
@@ -128,15 +145,19 @@ export default ({ cwd, development }) => {
 };
 ```
 
-Once you've defined your custom values in the schema file, you can override them in the common.json and host/environment-specific config files.
+Once you've defined your custom values in the schema file, you can override them in the common.json and
+host/environment-specific config files.
 
 ## Step 5: Set environment variables for hosts and environments
 
-Set the HOST and ENV environment variables when starting your app to specify the host and environment you want to use. For example:
+Set the HOST and ENV environment variables when starting your app to specify the host and environment you want to use.
+For example:
 
 ```
 HOST=www.example.com ENV=staging npm run start
 ```
+
 This will use the configuration values specified in config/hosts/www.example.com/config.staging.json.
 
-Now, you have successfully configured your Podium podlet server using the config system. You can further customize and extend your podlet server using the various features and configurations available in the Podium podlet server package.
+Now, you have successfully configured your Podium podlet server using the config system. You can further customize and
+extend your podlet server using the various features and configurations available in the Podium podlet server package.

--- a/lib/config.js
+++ b/lib/config.js
@@ -63,15 +63,22 @@ export default async function configuration({ schemas = [], cwd = process.cwd() 
   }
 
   // load specific overrides if provided
-  // fine grained config overrides. Hosts and env overrides etc.
-  if (existsSync(join(cwd, `${join("config", "hosts", host, "config")}.${env}.json`))) {
-    config.loadFile(join(cwd, `${join("config", "hosts", host, "config")}.${env}.json`));
+  // fine-grained config overrides. Hosts and env overrides etc.
+  const outdatedOverridePath = `${join("config", "hosts", host, "config")}.${env}.json`;
+  const newOverridePath = `${join("config", "hosts", host, env)}.json`;
+  if (existsSync(join(cwd, outdatedOverridePath))) {
+    console.warn(
+      `Deprecation warning: Your config override use an outdated path "${outdatedOverridePath}". The new format is: "${newOverridePath}"`,
+    );
+    config.loadFile(join(cwd, outdatedOverridePath));
+  } else if (existsSync(join(cwd, newOverridePath))) {
+    config.loadFile(join(cwd, newOverridePath));
   }
 
   // validate the name field of package.json
   if (name === config.get("app.name") && !/^[a-z-]*$/.test(name)) {
     throw new Error(
-      `Name field in package.json was not usable as a default app name because it uses characters other than a-z and -.\nYou have 2 choices:\n1. Either set it to a different name using lower case letters and the - character\n2. keep it as is and define the app name in config.\nA good place for this is in /config/common.json\neg. { "app": { "name": "my-app-name-here" } }"`
+      `Name field in package.json was not usable as a default app name because it uses characters other than a-z and -.\nYou have 2 choices:\n1. Either set it to a different name using lower case letters and the - character\n2. keep it as is and define the app name in config.\nA good place for this is in /config/common.json\neg. { "app": { "name": "my-app-name-here" } }"`,
     );
   }
 


### PR DESCRIPTION
This PR looks to make the naming scheme for configuration overrides a bit nicer 💅 

### Previously
```
config/host/<hostname>/config.<env>.json
```
### This is the way
```
config/host/<hostname>/<env>.json
```
We omit the "config" from the file name 🤷 

If you use the old format, we print a deprecation warning:
```
Deprecation warning: Your config override use an outdated path "config/hosts/example.com/config.prod.json". The new format
is: "config/hosts/example.com/prod.json"
```
Ideally this should have been logged with a logger, but this should be handled in a different PR.