### PR TITLE
Support top level await

### DIFF
--- a/api/build.js
+++ b/api/build.js
@@ -186,6 +186,7 @@ export async function build({ state, config, cwd = process.cwd() }) {
       ],
       entryPoints,
       bundle: true,
+      format: 'esm', // default format when bundling is IIFE
       write: false,
       outdir: ESBUILD_OUTDIR,
     });

--- a/api/build.js
+++ b/api/build.js
@@ -146,9 +146,11 @@ export async function build({ state, config, cwd = process.cwd() }) {
           name: 'esbuild-apply-plugins',
           setup(buildInstance) {
             buildInstance.onResolve(
-              { filter: /(content|fallback|lazy|scripts|src).*.(ts|js)$/ },
+              {
+                filter: /(content|fallback|lazy|scripts|src).*.(ts|js)$/,
+                namespace: 'file',
+              },
               async (args) => {
-                if (args.namespace !== 'file') return;
                 if (args.path.includes('node_modules')) return;
 
                 let file = args.path;


### PR DESCRIPTION
I noticed when I tried to change a podlet from `ssr-only` to `hydrate`, the build broke because of a top-level await with some message about how it isn't supported in IIFE, which is the default output. The previous `esbuild` is configured with ESM output, so I figure we might have intended to do that for all of it?