### PR TITLE
fix: don't include dev scripts in prod for hydration mode

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -207,7 +207,7 @@ export default fp(
                         prefix,
                         '/_/dynamic/modules/@lit-labs/ssr-client/lit-element-hydrate-support.js',
                       ),
-                      { dev: development },
+                      { dev: true },
                     )
                   : '';
               let markup;
@@ -267,7 +267,7 @@ export default fp(
                         prefix,
                         '/_/dynamic/modules/@lit-labs/ssr-client/lit-element-hydrate-support.js',
                       ),
-                      { dev: development },
+                      { dev: true },
                     )
                   : '';
               let markup;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "test": "tap --timeout 60000 --no-check-coverage --no-coverage-report test/**/*.test.js",
+    "test": "NODE_OPTIONS=--conditions=development tap --timeout 60000 --no-check-coverage --no-coverage-report test/**/*.test.js",
     "prepublish": "tsc"
   },
   "keywords": [],

--- a/plugins/script.js
+++ b/plugins/script.js
@@ -1,11 +1,18 @@
 import fp from 'fastify-plugin';
 
 export default fp(async (fastify, { development = false }) => {
-  fastify.decorate('script', (url, { dev = false, lazy = false } = {}) => {
-    if (!development && dev) return '';
-    if (lazy) {
-      return `<script type="module">addEventListener('load',()=>import('${url}'))</script>`;
-    }
-    return `<script type="module" src="${url}"></script>`;
-  });
+  fastify.decorate(
+    'script',
+    /**
+     * @param {string} url
+     * @param {{ dev?: boolean, lazy?: boolean }} options – dev: only in development, lazy: dynamic import on load event
+     */
+    (url, { dev = false, lazy = false } = {}) => {
+      if (!development && dev) return '';
+      if (lazy) {
+        return `<script type="module">addEventListener('load',()=>import('${url}'))</script>`;
+      }
+      return `<script type="module" src="${url}"></script>`;
+    },
+  );
 });

--- a/test/api/start.test.js
+++ b/test/api/start.test.js
@@ -64,12 +64,20 @@ test('Starting with package.json file in directory', async (t) => {
 });
 
 test('Starting with content file in directory', async (t) => {
+  const { default: packageJson } = await import('../../package.json', {
+    assert: { type: 'json' },
+  });
+
   await writeFile(
     join(tmp, 'package.json'),
     JSON.stringify({
       name: 'test-app',
       type: 'module',
-      dependencies: { lit: '*', '@lit-labs/ssr-client': '*' },
+      dependencies: {
+        lit: packageJson.dependencies.lit,
+        '@lit-labs/ssr-client':
+          packageJson.dependencies['@lit-labs/ssr-client'],
+      },
     }),
   );
   await writeFile(
@@ -77,7 +85,7 @@ test('Starting with content file in directory', async (t) => {
     `
     import { html, LitElement } from "lit";
     export default class Content extends LitElement {
-        render() { 
+        render() {
             return html\`<div>hello world</div>\`;
         }
     }
@@ -123,12 +131,19 @@ test('Using validated query parameters in server.js', async (t) => {
     }
   `.trim(),
   );
+  const { default: packageJson } = await import('../../package.json', {
+    assert: { type: 'json' },
+  });
   await writeFile(
     join(tmp, 'package.json'),
     JSON.stringify({
       name: 'test-app',
       type: 'module',
-      dependencies: { lit: '*', '@lit-labs/ssr-client': '*' },
+      dependencies: {
+        lit: packageJson.dependencies.lit,
+        '@lit-labs/ssr-client':
+          packageJson.dependencies['@lit-labs/ssr-client'],
+      },
     }),
   );
   await writeFile(
@@ -136,7 +151,7 @@ test('Using validated query parameters in server.js', async (t) => {
     `
     import { html, LitElement } from "lit";
     export default class Content extends LitElement {
-        render() { 
+        render() {
             return html\`<div>hello world</div>\`;
         }
     }
@@ -170,18 +185,25 @@ test('Fallback route', async (t) => {
     `
   import { html, LitElement } from "lit";
   export default class Content extends LitElement {
-      render() { 
+      render() {
           return html\`<div>Fallback content</div>\`;
       }
   }
   `.trim(),
   );
+  const { default: packageJson } = await import('../../package.json', {
+    assert: { type: 'json' },
+  });
   await writeFile(
     join(tmp, 'package.json'),
     JSON.stringify({
       name: 'test-app',
       type: 'module',
-      dependencies: { lit: '*', '@lit-labs/ssr-client': '*' },
+      dependencies: {
+        lit: packageJson.dependencies.lit,
+        '@lit-labs/ssr-client':
+          packageJson.dependencies['@lit-labs/ssr-client'],
+      },
     }),
   );
   execSync('npm install', { cwd: tmp });
@@ -209,12 +231,15 @@ test('scripts.js loading', async (t) => {
     console.log("This script will be loaded after the main podlet scripts.");
   `.trim(),
   );
+  const { default: packageJson } = await import('../../package.json', {
+    assert: { type: 'json' },
+  });
   await writeFile(
     join(tmp, 'package.json'),
     JSON.stringify({
       name: 'test-app',
       type: 'module',
-      dependencies: { lit: '*' },
+      dependencies: { lit: packageJson.dependencies.lit },
     }),
   );
   await writeFile(
@@ -222,7 +247,7 @@ test('scripts.js loading', async (t) => {
     `
     import { html, LitElement } from "lit";
     export default class Content extends LitElement {
-        render() { 
+        render() {
             return html\`<div>hello world</div>\`;
         }
     }
@@ -261,18 +286,21 @@ test('lazy.js loading', async (t) => {
     `
     import { html, LitElement } from "lit";
     export default class Content extends LitElement {
-        render() { 
+        render() {
             return html\`<div>hello world</div>\`;
         }
     }
     `.trim(),
   );
+  const { default: packageJson } = await import('../../package.json', {
+    assert: { type: 'json' },
+  });
   await writeFile(
     join(tmp, 'package.json'),
     JSON.stringify({
       name: 'test-app',
       type: 'module',
-      dependencies: { lit: '*' },
+      dependencies: { lit: packageJson.dependencies.lit },
     }),
   );
   execSync('npm install', { cwd: tmp });

--- a/test/lib/plugin.test.js
+++ b/test/lib/plugin.test.js
@@ -17,7 +17,7 @@ const tmp = join(tmpdir(), './plugin.test.js');
 const contentFile = `
 import { html, LitElement } from "lit";
 export default class Element extends LitElement {
-  render() { 
+  render() {
     return html\`<div>hello world</div>\`;
   }
 }
@@ -39,6 +39,7 @@ async function setupConfig() {
   const config = convict({});
   // @ts-ignore
   config.set('app.name', 'test-app');
+  config.set('app.base', '/');
   config.set('app.port', 0);
   config.set('assets.base', '/static');
   config.set('podlet.version', '1.0.0');
@@ -331,6 +332,52 @@ test('schemas: fallback.json', async (t) => {
   const queryParam = await fetch(`${address}/fallback?test=1`);
   t.equal(noQueryParm.status, 400);
   t.equal(queryParam.status, 200);
+  await app.close();
+});
+
+test('hydrate: dev mode includes lit-element-hydrate-support as a script tag', async (t) => {
+  const app = fastify({ logger: false });
+  const config = await setupConfig();
+  config.set('app.mode', 'hydrate');
+  config.set('app.development', true);
+
+  await app.register(plugin, {
+    cwd: tmp,
+    config,
+  });
+
+  const address = await app.listen({ port: 0 });
+  const content = await fetch(`${address}/`);
+  const markup = await content.text();
+  t.equal(content.status, 200, 'content file should be sucessfully served');
+  t.match(
+    markup,
+    '/_/dynamic/modules/@lit-labs/ssr-client/lit-element-hydrate-support.js',
+    'should contain lit-element-hydrate-support script',
+  );
+  await app.close();
+});
+
+test('hydrate: production mode does not include lit-element-hydrate-support as a script tag', async (t) => {
+  const app = fastify({ logger: false });
+  const config = await setupConfig();
+  config.set('app.mode', 'hydrate');
+  config.set('app.development', false);
+
+  await app.register(plugin, {
+    cwd: tmp,
+    config,
+  });
+
+  const address = await app.listen({ port: 0 });
+  const content = await fetch(`${address}/`);
+  const markup = await content.text();
+  t.equal(content.status, 200, 'content file should be sucessfully served');
+  t.notMatch(
+    markup,
+    '/_/dynamic/modules/@lit-labs/ssr-client/lit-element-hydrate-support.js',
+    'should not contain lit-element-hydrate-support script tag when development: false',
+  );
   await app.close();
 });
 

--- a/test/lib/plugin.test.js
+++ b/test/lib/plugin.test.js
@@ -64,12 +64,15 @@ beforeEach(async () => {
   await mkdir(tmp);
   await mkdir(join(tmp, 'schemas'));
   await mkdir(join(tmp, 'locale'));
+  const { default: packageJson } = await import('../../package.json', {
+    assert: { type: 'json' },
+  });
   await writeFile(
     join(tmp, 'package.json'),
     JSON.stringify({
       name: 'test-app',
       type: 'module',
-      dependencies: { lit: '*' },
+      dependencies: { lit: packageJson.dependencies.lit },
     }),
   );
   await mkdir(join(tmp, 'dist'));

--- a/test/plugins/plugins-csr.test.js
+++ b/test/plugins/plugins-csr.test.js
@@ -13,12 +13,15 @@ const tmp = join(tmpdir(), './plugins-csr.test.js');
 
 beforeEach(async () => {
   await mkdir(tmp);
+  const { default: packageJson } = await import('../../package.json', {
+    assert: { type: 'json' },
+  });
   await writeFile(
     join(tmp, 'package.json'),
     JSON.stringify({
       name: 'test-app',
       type: 'module',
-      dependencies: { lit: '*' },
+      dependencies: { lit: packageJson.dependencies.lit },
     }),
   );
   await mkdir(join(tmp, 'dist'));
@@ -27,7 +30,7 @@ beforeEach(async () => {
     `
     import { html, LitElement } from "lit";
     export default class Element extends LitElement {
-        render() { 
+        render() {
             return html\`<div>hello world</div>\`;
         }
     }

--- a/test/plugins/plugins-hydrate.test.js
+++ b/test/plugins/plugins-hydrate.test.js
@@ -14,12 +14,15 @@ const tmp = join(tmpdir(), './plugins-hydrate.test.js');
 
 beforeEach(async () => {
   await mkdir(tmp);
+  const { default: packageJson } = await import('../../package.json', {
+    assert: { type: 'json' },
+  });
   await writeFile(
     join(tmp, 'package.json'),
     JSON.stringify({
       name: 'test-app',
       type: 'module',
-      dependencies: { lit: '*' },
+      dependencies: { lit: packageJson.dependencies.lit },
     }),
   );
   await mkdir(join(tmp, 'dist'));
@@ -28,7 +31,7 @@ beforeEach(async () => {
     `
     import { html, LitElement } from "lit";
     export default class Element extends LitElement {
-        render() { 
+        render() {
             return html\`<div>hello world</div>\`;
         }
     }

--- a/test/plugins/plugins-ssr.test.js
+++ b/test/plugins/plugins-ssr.test.js
@@ -14,12 +14,15 @@ const tmp = join(tmpdir(), './plugins-ssr.test.js');
 
 beforeEach(async () => {
   await mkdir(tmp);
+  const { default: packageJson } = await import('../../package.json', {
+    assert: { type: 'json' },
+  });
   await writeFile(
     join(tmp, 'package.json'),
     JSON.stringify({
       name: 'test-app',
       type: 'module',
-      dependencies: { lit: '*' },
+      dependencies: { lit: packageJson.dependencies.lit },
     }),
   );
   await mkdir(join(tmp, 'dist'));
@@ -28,7 +31,7 @@ beforeEach(async () => {
     `
     import { html, LitElement } from "lit";
     export default class Element extends LitElement {
-        render() { 
+        render() {
             return html\`<div>hello world</div>\`;
         }
     }


### PR DESCRIPTION
- Fixes a bug where we'd render dev script tags in production
- Sets an environment variable for unit tests to workaround a bug in Lit
- Read Lit version from package.json instead of testing with wildcard

Context: https://github.com/podium-lib/podlet-server/pull/78#discussion_r1373274935