### PR TITLE
Replace process.env.NODE_ENV on client-side for dependencies

### DIFF
--- a/api/build.js
+++ b/api/build.js
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 import esbuild from 'esbuild';
 import rollupPluginTerser from '@rollup/plugin-terser';
+import rollupPluginReplace from '@rollup/plugin-replace';
 import { rollup } from 'rollup';
 import rollupPluginResolve from '@rollup/plugin-node-resolve';
 import rollupPluginCommonjs from '@rollup/plugin-commonjs';
@@ -219,6 +220,15 @@ export async function build({ state, config, cwd = process.cwd() }) {
           rollupPluginCommonjs({ include: /node_modules/ }),
           rollupPluginTerser({ format: { comments: false } }),
         ];
+
+        if (outfile) {
+          rollupPlugins.push(
+            rollupPluginReplace({
+              'process.env.NODE_ENV': JSON.stringify('production'),
+              preventAssignment: true,
+            }),
+          );
+        }
 
         if (existsSync(join(cwd, 'tsconfig.json'))) {
           rollupPlugins.unshift(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@podium/podlet-server",
-  "version": "1.10.4",
+  "version": "1.10.4-next.1",
   "type": "module",
   "bin": {
     "podlet": "./cli.js"
@@ -46,6 +46,7 @@
     "@podium/podlet": "5.0.0-next.6",
     "@rollup/plugin-commonjs": "25.0.2",
     "@rollup/plugin-node-resolve": "15.1.0",
+    "@rollup/plugin-replace": "5.0.4",
     "@rollup/plugin-terser": "0.4.3",
     "@rollup/plugin-typescript": "11.1.2",
     "@webcomponents/template-shadowroot": "0.2.1",


### PR DESCRIPTION
`esbuild` would do this for our own code, but I've seen an issue where a dependency bundled by Rollup expected us to do this type of replacement ([lingui-core](https://github.com/lingui/js-lingui/blob/04b7cef9876168bc376b55424ecc0b0ebde976c1/packages/core/src/i18n.ts#L198)).